### PR TITLE
feat: index a model on multiple indexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## DEV
 
+## v0.8.0 - 2023-06-01
+
+#### Breaking changes
+
+- Errors for `get_object` and `get_objects` are now of arity 4 and retunrs the original request as last attribute
+
+#### New
+
+- Added possibility to have multiple indexes for a model (applies for replicas as well)
+- Added `build_object/2` with the index name as second parameter (useful for translations for example)
+
 ## v0.7.0 - 2022-03-29
 
 #### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 #### Breaking changes
 
-- Errors for `get_object` and `get_objects` are now of arity 4 and retunrs the original request as last attribute
+- Errors for `get_object` and `get_objects` are now of arity 4 and returns the original request as last attribute
 
 #### New
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ end
 
 It's possible to define multiple indexes for a same model.
 
-To do this just specify an array of index names, or in your `index_name/0` runtime function, return an array.
+To achieve this, just specify an array of index names, or simply return an array in your `index_name/0` runtime function
 
 ```elixir
 defmodule Article do

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ use Algoliax.Indexer,
   ]
 ```
 
-If the main index holds multiple indexes, for an index per language for example, replicas needs to hold the same amount of names.
+If the main index holds multiple indexes (e.g for an index per language usecase), replicas need to hold the same amount of names.
 The order is important to be associated to the correct main index.
 
 ```elixir

--- a/lib/algoliax.ex
+++ b/lib/algoliax.ex
@@ -88,8 +88,7 @@ defmodule Algoliax do
 
   def wait_task({:ok, responses}) when is_list(responses) do
     responses
-    |> Enum.map(fn %Algoliax.Responses{responses: tasks} -> wait_task(tasks) end)
-    |> List.flatten()
+    |> Enum.flat_map(fn %Algoliax.Responses{responses: tasks} -> wait_task(tasks) end)
   end
 
   def wait_task(tasks) when is_list(tasks) do

--- a/lib/algoliax/client.ex
+++ b/lib/algoliax/client.ex
@@ -26,7 +26,7 @@ defmodule Algoliax.Client do
         build_response(response, request)
 
       {:ok, code, _, response} when code in 300..499 ->
-        handle_error(code, response, action)
+        handle_error(code, response, action, request)
 
       error ->
         Logger.debug("#{inspect(error)}")
@@ -34,11 +34,11 @@ defmodule Algoliax.Client do
     end
   end
 
-  defp handle_error(404, response, action) when action in [:get_settings, :get_object] do
-    {:error, 404, response}
+  defp handle_error(404, response, action, request) when action in [:get_settings, :get_object] do
+    {:error, 404, response, request}
   end
 
-  defp handle_error(code, response, _action) do
+  defp handle_error(code, response, _action, _request) do
     error =
       case Jason.decode(response) do
         {:ok, response} -> Map.get(response, "message")

--- a/lib/algoliax/exceptions.ex
+++ b/lib/algoliax/exceptions.ex
@@ -10,6 +10,11 @@ defmodule Algoliax.MissingRepoError do
   defexception [:message]
 
   @impl true
+  def exception(index_name) when is_list(index_name) do
+    %__MODULE__{message: "No repo configured for indexes #{Enum.join(index_name, ", ")}"}
+  end
+
+  @impl true
   def exception(index_name) do
     %__MODULE__{message: "No repo configured for index #{index_name}"}
   end

--- a/lib/algoliax/indexer.ex
+++ b/lib/algoliax/indexer.ex
@@ -293,6 +293,7 @@ defmodule Algoliax.Indexer do
       end
   """
   @callback build_object(model :: map()) :: map()
+  @callback build_object(model :: map(), index :: String.t()) :: map()
 
   @doc """
   Check if current object must be indexed or not. By default it's always true. To override this behaviour override this function in your model
@@ -430,6 +431,11 @@ defmodule Algoliax.Indexer do
       end
 
       @impl Algoliax.Indexer
+      def build_object(_, _) do
+        %{}
+      end
+
+      @impl Algoliax.Indexer
       def to_be_indexed?(_) do
         true
       end
@@ -439,7 +445,7 @@ defmodule Algoliax.Indexer do
         :default
       end
 
-      defoverridable(to_be_indexed?: 1, build_object: 1, get_object_id: 1)
+      defoverridable(to_be_indexed?: 1, build_object: 1, build_object: 2, get_object_id: 1)
     end
   end
 end

--- a/lib/algoliax/indexer.ex
+++ b/lib/algoliax/indexer.ex
@@ -3,7 +3,7 @@ defmodule Algoliax.Indexer do
 
   ### Usage
 
-  - `:index_name`: specificy the index where the object will be added on. **Required**
+  - `:index_name`: specificy the index or indexes where the object will be added on. **Required**
   - `:object_id`: specify the attribute used to as algolia objectID. Default `:id`.
   - `:repo`: Specify an Ecto repo to be use to fecth records. Default `nil`
   - `:cursor_field`: specify the column to be used to order and go through a given table. Default `:id`
@@ -140,6 +140,10 @@ defmodule Algoliax.Indexer do
       "processingTimeMS" => 1,
       "query" => "john"
       }}
+
+      iex> PeopleWithMultipleIndexes.search("John")
+
+      [{:ok, %{}}, {:ok, %{}}]
   """
 
   @callback search(query :: binary(), params :: map()) ::
@@ -167,6 +171,8 @@ defmodule Algoliax.Indexer do
           ],
           "processingTimeMS" => 1
         }}
+      iex> PeopleWithMultipleIndexes.search_facet("age")
+      [{:ok, %{}}, {:ok, %{}}]
   """
   @callback search_facet(facet_name :: binary(), facet_query :: binary(), params :: map()) ::
               {:ok, Algoliax.Response.t()} | {:not_indexable, model :: map()}
@@ -178,6 +184,9 @@ defmodule Algoliax.Indexer do
       people = %People{reference: 10, last_name: "Doe", first_name: "John", age: 20},
 
       People.save_object(people)
+
+      iex> PeopleWithMultipleIndexes.save_object(people)
+      [{:ok, %{}}, {:ok, %{}}]
   """
   @callback save_object(object :: map() | struct()) ::
               {:ok, Algoliax.Response.t()} | {:not_indexable, model :: map()}
@@ -281,10 +290,20 @@ defmodule Algoliax.Indexer do
 
   @doc """
   Build the object sent to algolia. By default the object contains only `objectID` set by Algoliax.Indexer
+  build_object/2 provides the index name for the ongoing build
 
   ## Example
       @impl Algoliax.Indexer
       def build_object(person) do
+        %{
+          age: person.age,
+          last_name: person.last_name,
+          first_name: person.first_name
+        }
+      end
+
+      @impl Algoliax.Indexer
+      def build_object(person, _index_name) do
         %{
           age: person.age,
           last_name: person.last_name,

--- a/lib/algoliax/indexer.ex
+++ b/lib/algoliax/indexer.ex
@@ -3,7 +3,7 @@ defmodule Algoliax.Indexer do
 
   ### Usage
 
-  - `:index_name`: specificy the index or indexes where the object will be added on. **Required**
+  - `:index_name`: specificy the index or a list of indexes where the object will be added on. **Required**
   - `:object_id`: specify the attribute used to as algolia objectID. Default `:id`.
   - `:repo`: Specify an Ecto repo to be use to fecth records. Default `nil`
   - `:cursor_field`: specify the column to be used to order and go through a given table. Default `:id`

--- a/lib/algoliax/indexer.ex
+++ b/lib/algoliax/indexer.ex
@@ -142,12 +142,13 @@ defmodule Algoliax.Indexer do
       }}
 
       iex> PeopleWithMultipleIndexes.search("John")
-
-      [{:ok, %{}}, {:ok, %{}}]
+      {:ok, [%{index_name: "people", responses: [%{"exhaustiveNbHits" => true, ...}, ...]}, ...]}
   """
 
   @callback search(query :: binary(), params :: map()) ::
-              {:ok, Algoliax.Response.t()} | {:not_indexable, model :: map()}
+              {:ok, Algoliax.Response.t()}
+              | {:ok, list(Algoliax.Responses.t())}
+              | {:not_indexable, model :: map()}
 
   @doc """
   Search for facet values
@@ -171,11 +172,14 @@ defmodule Algoliax.Indexer do
           ],
           "processingTimeMS" => 1
         }}
+
       iex> PeopleWithMultipleIndexes.search_facet("age")
-      [{:ok, %{}}, {:ok, %{}}]
+      {:ok, [%{index_name: "people", responses: [%{"exhaustiveNbHits" => true, ...}, ...]}, ...]}
   """
   @callback search_facet(facet_name :: binary(), facet_query :: binary(), params :: map()) ::
-              {:ok, Algoliax.Response.t()} | {:not_indexable, model :: map()}
+              {:ok, Algoliax.Response.t()}
+              | {:ok, list(Algoliax.Responses.t())}
+              | {:not_indexable, model :: map()}
 
   @doc """
   Add/update object. The object is added/updated to algolia with the object_id configured.
@@ -186,10 +190,12 @@ defmodule Algoliax.Indexer do
       People.save_object(people)
 
       iex> PeopleWithMultipleIndexes.save_object(people)
-      [{:ok, %{}}, {:ok, %{}}]
+      {:ok, [%{index_name: "people", responses: [%{"exhaustiveNbHits" => true, ...}, ...]}, ...]}
   """
   @callback save_object(object :: map() | struct()) ::
-              {:ok, Algoliax.Response.t()} | {:not_indexable, model :: map()}
+              {:ok, Algoliax.Response.t()}
+              | {:ok, list(Algoliax.Responses.t())}
+              | {:not_indexable, model :: map()}
 
   @doc """
   Save multiple object at once
@@ -209,7 +215,7 @@ defmodule Algoliax.Indexer do
       People.save_objects(peoples, force_delete: true)
   """
   @callback save_objects(models :: list(map()) | list(struct()), opts :: Keyword.t()) ::
-              {:ok, Algoliax.Response.t()} | {:error, map()}
+              {:ok, Algoliax.Response.t()} | {:ok, list(Algoliax.Responses.t())} | {:error, map()}
 
   @doc """
   Fetch object from algolia. By passing the model, the object is retrieved using the object_id configured
@@ -220,7 +226,7 @@ defmodule Algoliax.Indexer do
       People.get_object(people)
   """
   @callback get_object(model :: map() | struct()) ::
-              {:ok, Algoliax.Response.t()} | {:error, map()}
+              {:ok, Algoliax.Response.t()} | {:ok, list(Algoliax.Responses.t())} | {:error, map()}
 
   @doc """
   Delete object from algolia. By passing the model, the object is retrieved using the object_id configured
@@ -231,7 +237,7 @@ defmodule Algoliax.Indexer do
       People.delete_object(people)
   """
   @callback delete_object(model :: map() | struct()) ::
-              {:ok, Algoliax.Response.t()} | {:error, map()}
+              {:ok, Algoliax.Response.t()} | {:ok, list(Algoliax.Responses.t())} | {:error, map()}
 
   @doc """
   Delete objects from algolia. By passing a matching filter query, the records are retrieved and deleted.[Filters](https://www.algolia.com/doc/api-reference/api-parameters/filters/)
@@ -240,7 +246,7 @@ defmodule Algoliax.Indexer do
       People.delete_by("age > 18")
   """
   @callback delete_by(matching_filter :: String.t()) ::
-              {:ok, Algoliax.Response.t()} | {:error, map()}
+              {:ok, Algoliax.Response.t()} | {:ok, list(Algoliax.Responses.t())} | {:error, map()}
 
   if Code.ensure_loaded?(Ecto) do
     @doc """
@@ -267,7 +273,7 @@ defmodule Algoliax.Indexer do
     > NOTE: filters as Map supports only `:where` and equality
     """
     @callback reindex(query :: Ecto.Query.t(), opts :: Keyword.t()) ::
-                {:ok, [Algoliax.Response.t()]}
+                {:ok, [Algoliax.Response.t()]} | {:ok, list(Algoliax.Responses.t())}
 
     @doc """
     Reindex all objects ([Ecto](https://hexdocs.pm/ecto/Ecto.html) specific)
@@ -280,12 +286,13 @@ defmodule Algoliax.Indexer do
 
     - `:force_delete`: delete objects where `to_be_indexed?` is `false`
     """
-    @callback reindex(opts :: Keyword.t()) :: {:ok, [Algoliax.Response.t()]}
+    @callback reindex(opts :: Keyword.t()) ::
+                {:ok, [Algoliax.Response.t()]} | {:ok, list(Algoliax.Responses.t())}
 
     @doc """
     Reindex atomically ([Ecto](https://hexdocs.pm/ecto/Ecto.html) specific)
     """
-    @callback reindex_atomic() :: {:ok, :completed}
+    @callback reindex_atomic() :: {:ok, :completed} | list({:ok, :completed})
   end
 
   @doc """
@@ -351,17 +358,17 @@ defmodule Algoliax.Indexer do
   @doc """
   Get index settings from Algolia
   """
-  @callback get_settings() :: {:ok, map()} | {:error, map()}
+  @callback get_settings() :: {:ok, map()} | {:ok, list(map())} | {:error, map()}
 
   @doc """
   Configure index
   """
-  @callback configure_index() :: {:ok, map()} | {:error, map()}
+  @callback configure_index() :: {:ok, map()} | {:ok, list(map())} | {:error, map()}
 
   @doc """
   Delete index
   """
-  @callback delete_index() :: {:ok, map()} | {:error, map()}
+  @callback delete_index() :: {:ok, map()} | {:ok, list(map())} | {:error, map()}
 
   defmacro __using__(settings) do
     quote do

--- a/lib/algoliax/resources/index.ex
+++ b/lib/algoliax/resources/index.ex
@@ -1,7 +1,7 @@
 defmodule Algoliax.Resources.Index do
   @moduledoc false
 
-  import Algoliax.Utils, only: [index_name: 2, algolia_settings: 1, render_result: 1]
+  import Algoliax.Utils, only: [index_name: 2, algolia_settings: 1, render_response: 1]
   import Algoliax.Client, only: [request: 1]
 
   alias Algoliax.{Settings, SettingsStore}
@@ -60,7 +60,7 @@ defmodule Algoliax.Resources.Index do
       SettingsStore.set_settings(index_name, algolia_remote_settings)
       algolia_remote_settings
     end)
-    |> render_result()
+    |> render_response()
   end
 
   def configure_index(module, settings) do
@@ -76,7 +76,7 @@ defmodule Algoliax.Resources.Index do
       configure_replicas(module, settings)
       r
     end)
-    |> render_result()
+    |> render_response()
   end
 
   def configure_replicas(module, settings) do
@@ -107,7 +107,7 @@ defmodule Algoliax.Resources.Index do
     |> Enum.map(fn index_name ->
       request(%{action: :delete_index, url_params: [index_name: index_name]})
     end)
-    |> render_result()
+    |> render_response()
   end
 
   defp settings_to_algolia_settings(module, settings, replica_index) do

--- a/lib/algoliax/resources/index.ex
+++ b/lib/algoliax/resources/index.ex
@@ -1,7 +1,7 @@
 defmodule Algoliax.Resources.Index do
   @moduledoc false
 
-  import Algoliax.Utils, only: [index_name: 2, algolia_settings: 1]
+  import Algoliax.Utils, only: [index_name: 2, algolia_settings: 1, render_result: 1]
   import Algoliax.Client, only: [request: 1]
 
   alias Algoliax.{Settings, SettingsStore}
@@ -60,10 +60,7 @@ defmodule Algoliax.Resources.Index do
       SettingsStore.set_settings(index_name, algolia_remote_settings)
       algolia_remote_settings
     end)
-    |> case do
-      [single_result] -> single_result
-      [_ | _] = multiple_result -> multiple_result
-    end
+    |> render_result()
   end
 
   def configure_index(module, settings) do
@@ -79,10 +76,7 @@ defmodule Algoliax.Resources.Index do
       configure_replicas(module, settings)
       r
     end)
-    |> case do
-      [single_result] -> single_result
-      [_ | _] = multiple_result -> multiple_result
-    end
+    |> render_result()
   end
 
   def configure_replicas(module, settings) do
@@ -113,10 +107,7 @@ defmodule Algoliax.Resources.Index do
     |> Enum.map(fn index_name ->
       request(%{action: :delete_index, url_params: [index_name: index_name]})
     end)
-    |> case do
-      [single_result] -> single_result
-      [_ | _] = multiple_result -> multiple_result
-    end
+    |> render_result()
   end
 
   defp settings_to_algolia_settings(module, settings, replica_index) do

--- a/lib/algoliax/resources/object.ex
+++ b/lib/algoliax/resources/object.ex
@@ -1,11 +1,13 @@
 defmodule Algoliax.Resources.Object do
   @moduledoc false
 
-  import Algoliax.Utils, only: [index_name: 2, object_id_attribute: 1]
+  import Algoliax.Utils, only: [index_name: 2, object_id_attribute: 1, render_result: 1]
   import Algoliax.Client, only: [request: 1]
 
   alias Algoliax.TemporaryIndexer
 
+  # TODO: mutli-query call
+  # TODO: retour save query
   def get_object(module, settings, model) do
     index_name(module, settings)
     |> Enum.map(fn index_name ->
@@ -17,10 +19,7 @@ defmodule Algoliax.Resources.Object do
         ]
       })
     end)
-    |> case do
-      [single_result] -> single_result
-      [_ | _] = multiple_result -> multiple_result
-    end
+    |> render_result()
   end
 
   def save_objects(module, settings, models, opts) do
@@ -52,10 +51,7 @@ defmodule Algoliax.Resources.Object do
           body: %{requests: objects}
         })
       end)
-      |> case do
-        [single_result] -> single_result
-        [_ | _] = multiple_result -> multiple_result
-      end
+      |> render_result()
     end
   end
 
@@ -64,10 +60,7 @@ defmodule Algoliax.Resources.Object do
     |> Enum.map(fn index_name ->
       save_object(module, settings, model, index_name)
     end)
-    |> case do
-      [single_result] -> single_result
-      [_ | _] = multiple_result -> multiple_result
-    end
+    |> render_result()
   end
 
   defp save_object(module, settings, model, index_name) do
@@ -98,10 +91,7 @@ defmodule Algoliax.Resources.Object do
         ]
       })
     end)
-    |> case do
-      [single_result] -> single_result
-      [_ | _] = multiple_result -> multiple_result
-    end
+    |> render_result()
   end
 
   def delete_by(module, settings, matching_filter) do
@@ -126,10 +116,7 @@ defmodule Algoliax.Resources.Object do
         body: body
       })
     end)
-    |> case do
-      [single_result] -> single_result
-      [_ | _] = multiple_result -> multiple_result
-    end
+    |> render_result()
   end
 
   defp build_batch_object(module, settings, model, "deleteObject" = action, _index_name) do

--- a/lib/algoliax/resources/object.ex
+++ b/lib/algoliax/resources/object.ex
@@ -6,8 +6,6 @@ defmodule Algoliax.Resources.Object do
 
   alias Algoliax.TemporaryIndexer
 
-  # TODO: mutli-query call
-  # TODO: retour save query
   def get_object(module, settings, model) do
     index_name(module, settings)
     |> Enum.map(fn index_name ->

--- a/lib/algoliax/resources/object.ex
+++ b/lib/algoliax/resources/object.ex
@@ -1,7 +1,7 @@
 defmodule Algoliax.Resources.Object do
   @moduledoc false
 
-  import Algoliax.Utils, only: [index_name: 2, object_id_attribute: 1, render_result: 1]
+  import Algoliax.Utils, only: [index_name: 2, object_id_attribute: 1, render_response: 1]
   import Algoliax.Client, only: [request: 1]
 
   alias Algoliax.TemporaryIndexer
@@ -19,7 +19,7 @@ defmodule Algoliax.Resources.Object do
         ]
       })
     end)
-    |> render_result()
+    |> render_response()
   end
 
   def save_objects(module, settings, models, opts) do
@@ -51,7 +51,7 @@ defmodule Algoliax.Resources.Object do
           body: %{requests: objects}
         })
       end)
-      |> render_result()
+      |> render_response()
     end
   end
 
@@ -60,7 +60,7 @@ defmodule Algoliax.Resources.Object do
     |> Enum.map(fn index_name ->
       save_object(module, settings, model, index_name)
     end)
-    |> render_result()
+    |> render_response()
   end
 
   defp save_object(module, settings, model, index_name) do
@@ -91,7 +91,7 @@ defmodule Algoliax.Resources.Object do
         ]
       })
     end)
-    |> render_result()
+    |> render_response()
   end
 
   def delete_by(module, settings, matching_filter) do
@@ -116,7 +116,7 @@ defmodule Algoliax.Resources.Object do
         body: body
       })
     end)
-    |> render_result()
+    |> render_response()
   end
 
   defp build_batch_object(module, settings, model, "deleteObject" = action, _index_name) do

--- a/lib/algoliax/resources/object_ecto.ex
+++ b/lib/algoliax/resources/object_ecto.ex
@@ -4,38 +4,17 @@ if Code.ensure_loaded?(Ecto) do
 
     import Ecto.Query
     import Algoliax.Client, only: [request: 1]
-    import Algoliax.Utils, only: [index_name: 2, render_result: 1, schemas: 2]
+    import Algoliax.Utils, only: [index_name: 2, schemas: 2]
 
     alias Algoliax.Resources.Object
 
     def reindex(module, settings, %Ecto.Query{} = query, opts) do
       repo = Algoliax.UtilsEcto.repo(settings)
 
-      acc =
-        Algoliax.UtilsEcto.find_in_batches(repo, query, 0, settings, fn batch ->
-          Object.save_objects(module, settings, batch, opts)
-        end)
-        |> Enum.reject(&is_nil/1)
-        |> case do
-          [{:ok, %Algoliax.Response{}}] = objects ->
-            objects
-
-          [{:ok, %Algoliax.Response{}} | _] = objects ->
-            objects
-
-          objects ->
-            objects
-            |> Enum.reduce([], fn {:ok, responses}, acc -> acc ++ responses end)
-            |> Enum.group_by(& &1.index_name)
-            |> Enum.map(fn {index_name, list} ->
-              %Algoliax.Responses{
-                index_name: index_name,
-                responses: Enum.flat_map(list, & &1.responses)
-              }
-            end)
-        end
-
-      {:ok, acc}
+      Algoliax.UtilsEcto.find_in_batches(repo, query, 0, settings, fn batch ->
+        Object.save_objects(module, settings, batch, opts)
+      end)
+      |> render_reindex()
     end
 
     def reindex(module, settings, nil, opts) do
@@ -45,49 +24,28 @@ if Code.ensure_loaded?(Ecto) do
     def reindex(module, settings, query_filters, opts) when is_map(query_filters) do
       repo = Algoliax.UtilsEcto.repo(settings)
 
-      acc =
-        module
-        |> fetch_schemas(settings)
-        |> Enum.reduce([], fn {mod, preloads}, acc ->
-          where_filters = Map.get(query_filters, :where, [])
+      module
+      |> fetch_schemas(settings)
+      |> Enum.reduce([], fn {mod, preloads}, acc ->
+        where_filters = Map.get(query_filters, :where, [])
 
-          query =
-            from(m in mod)
-            |> where(^where_filters)
-            |> preload(^preloads)
+        query =
+          from(m in mod)
+          |> where(^where_filters)
+          |> preload(^preloads)
 
-          Algoliax.UtilsEcto.find_in_batches(
-            repo,
-            query,
-            0,
-            settings,
-            fn batch ->
-              Object.save_objects(module, settings, batch, opts)
-            end,
-            acc
-          )
-        end)
-        |> Enum.reject(&is_nil/1)
-        |> case do
-          [{:ok, %Algoliax.Response{}}] = objects ->
-            objects
-
-          [{:ok, %Algoliax.Response{}} | _] = objects ->
-            objects
-
-          objects ->
-            objects
-            |> Enum.reduce([], fn {:ok, responses}, acc -> acc ++ responses end)
-            |> Enum.group_by(& &1.index_name)
-            |> Enum.map(fn {index_name, list} ->
-              %Algoliax.Responses{
-                index_name: index_name,
-                responses: Enum.flat_map(list, & &1.responses)
-              }
-            end)
-        end
-
-      {:ok, acc}
+        Algoliax.UtilsEcto.find_in_batches(
+          repo,
+          query,
+          0,
+          settings,
+          fn batch ->
+            Object.save_objects(module, settings, batch, opts)
+          end,
+          acc
+        )
+      end)
+      |> render_reindex()
     end
 
     def reindex(_, _, _, _) do
@@ -133,7 +91,33 @@ if Code.ensure_loaded?(Ecto) do
           Algoliax.SettingsStore.stop_reindexing(index_name)
         end
       end)
-      |> render_result()
+      |> render_reindex_atomic()
     end
+
+    defp render_reindex(responses) do
+      results =
+        responses
+        |> Enum.reject(&is_nil/1)
+        |> case do
+          [{:ok, %Algoliax.Response{}} | _] = single_index_responses ->
+            single_index_responses
+
+          [{:ok, [%Algoliax.Responses{} | _]} | _] = multiple_index_responses ->
+            multiple_index_responses
+            |> Enum.reduce([], fn {:ok, responses}, acc -> acc ++ responses end)
+            |> Enum.group_by(& &1.index_name)
+            |> Enum.map(fn {index_name, list} ->
+              %Algoliax.Responses{
+                index_name: index_name,
+                responses: Enum.flat_map(list, & &1.responses)
+              }
+            end)
+        end
+
+      {:ok, results}
+    end
+
+    defp render_reindex_atomic([response]), do: response
+    defp render_reindex_atomic([_ | _] = responses), do: responses
   end
 end

--- a/lib/algoliax/resources/object_ecto.ex
+++ b/lib/algoliax/resources/object_ecto.ex
@@ -4,6 +4,7 @@ if Code.ensure_loaded?(Ecto) do
 
     import Ecto.Query
     import Algoliax.Client, only: [request: 1]
+    import Algoliax.Utils, only: [index_name: 2, render_result: 1, schemas: 2]
 
     alias Algoliax.Resources.Object
 
@@ -58,7 +59,7 @@ if Code.ensure_loaded?(Ecto) do
     end
 
     defp fetch_schemas(module, settings) do
-      Algoliax.Utils.schemas(settings, [module])
+      schemas(settings, [module])
       |> Enum.map(fn
         m when is_tuple(m) -> m
         m -> {m, []}
@@ -68,7 +69,7 @@ if Code.ensure_loaded?(Ecto) do
     def reindex_atomic(module, settings) do
       Algoliax.UtilsEcto.repo(settings)
 
-      Algoliax.Utils.index_name(module, settings)
+      index_name(module, settings)
       |> Enum.map(fn index_name ->
         tmp_index_name = :"#{index_name}.tmp"
 
@@ -96,10 +97,7 @@ if Code.ensure_loaded?(Ecto) do
           Algoliax.SettingsStore.stop_reindexing(index_name)
         end
       end)
-      |> case do
-        [single_result] -> single_result
-        [_ | _] = multiple_result -> multiple_result
-      end
+      |> render_result()
     end
   end
 end

--- a/lib/algoliax/resources/object_ecto.ex
+++ b/lib/algoliax/resources/object_ecto.ex
@@ -16,6 +16,24 @@ if Code.ensure_loaded?(Ecto) do
           Object.save_objects(module, settings, batch, opts)
         end)
         |> Enum.reject(&is_nil/1)
+        |> case do
+          [{:ok, %Algoliax.Response{}}] = objects ->
+            objects
+
+          [{:ok, %Algoliax.Response{}} | _] = objects ->
+            objects
+
+          objects ->
+            objects
+            |> Enum.reduce([], fn {:ok, responses}, acc -> acc ++ responses end)
+            |> Enum.group_by(& &1.index_name)
+            |> Enum.map(fn {index_name, list} ->
+              %Algoliax.Responses{
+                index_name: index_name,
+                responses: Enum.flat_map(list, & &1.responses)
+              }
+            end)
+        end
 
       {:ok, acc}
     end
@@ -50,6 +68,24 @@ if Code.ensure_loaded?(Ecto) do
           )
         end)
         |> Enum.reject(&is_nil/1)
+        |> case do
+          [{:ok, %Algoliax.Response{}}] = objects ->
+            objects
+
+          [{:ok, %Algoliax.Response{}} | _] = objects ->
+            objects
+
+          objects ->
+            objects
+            |> Enum.reduce([], fn {:ok, responses}, acc -> acc ++ responses end)
+            |> Enum.group_by(& &1.index_name)
+            |> Enum.map(fn {index_name, list} ->
+              %Algoliax.Responses{
+                index_name: index_name,
+                responses: Enum.flat_map(list, & &1.responses)
+              }
+            end)
+        end
 
       {:ok, acc}
     end

--- a/lib/algoliax/resources/search.ex
+++ b/lib/algoliax/resources/search.ex
@@ -1,6 +1,6 @@
 defmodule Algoliax.Resources.Search do
   @moduledoc false
-  import Algoliax.Utils, only: [index_name: 2, camelize: 1, render_result: 1]
+  import Algoliax.Utils, only: [index_name: 2, camelize: 1, render_response: 1]
   import Algoliax.Client, only: [request: 1]
 
   def search(module, settings, query, params) do
@@ -18,7 +18,7 @@ defmodule Algoliax.Resources.Search do
         body: body
       })
     end)
-    |> render_result()
+    |> render_response()
   end
 
   def search_facet(module, settings, facet_name, facet_query, params) do
@@ -40,6 +40,6 @@ defmodule Algoliax.Resources.Search do
         body: body
       })
     end)
-    |> render_result()
+    |> render_response()
   end
 end

--- a/lib/algoliax/resources/search.ex
+++ b/lib/algoliax/resources/search.ex
@@ -4,38 +4,48 @@ defmodule Algoliax.Resources.Search do
   import Algoliax.Client, only: [request: 1]
 
   def search(module, settings, query, params) do
-    index_name = index_name(module, settings)
+    index_name(module, settings)
+    |> Enum.map(fn index_name ->
+      body =
+        %{
+          query: query
+        }
+        |> Map.merge(camelize(params))
 
-    body =
-      %{
-        query: query
-      }
-      |> Map.merge(camelize(params))
-
-    request(%{
-      action: :search,
-      url_params: [index_name: index_name],
-      body: body
-    })
+      request(%{
+        action: :search,
+        url_params: [index_name: index_name],
+        body: body
+      })
+    end)
+    |> case do
+      [single_result] -> single_result
+      [_ | _] = multiple_result -> multiple_result
+    end
   end
 
   def search_facet(module, settings, facet_name, facet_query, params) do
-    index_name = index_name(module, settings)
+    index_name(module, settings)
+    |> Enum.map(fn index_name ->
+      body =
+        case facet_query do
+          nil ->
+            %{}
 
-    body =
-      case facet_query do
-        nil ->
-          %{}
+          _ ->
+            %{facetQuery: facet_query}
+        end
+        |> Map.merge(camelize(params))
 
-        _ ->
-          %{facetQuery: facet_query}
-      end
-      |> Map.merge(camelize(params))
-
-    request(%{
-      action: :search_facet,
-      url_params: [index_name: index_name, facet_name: facet_name],
-      body: body
-    })
+      request(%{
+        action: :search_facet,
+        url_params: [index_name: index_name, facet_name: facet_name],
+        body: body
+      })
+    end)
+    |> case do
+      [single_result] -> single_result
+      [_ | _] = multiple_result -> multiple_result
+    end
   end
 end

--- a/lib/algoliax/resources/search.ex
+++ b/lib/algoliax/resources/search.ex
@@ -1,6 +1,6 @@
 defmodule Algoliax.Resources.Search do
   @moduledoc false
-  import Algoliax.Utils, only: [index_name: 2, camelize: 1]
+  import Algoliax.Utils, only: [index_name: 2, camelize: 1, render_result: 1]
   import Algoliax.Client, only: [request: 1]
 
   def search(module, settings, query, params) do
@@ -18,10 +18,7 @@ defmodule Algoliax.Resources.Search do
         body: body
       })
     end)
-    |> case do
-      [single_result] -> single_result
-      [_ | _] = multiple_result -> multiple_result
-    end
+    |> render_result()
   end
 
   def search_facet(module, settings, facet_name, facet_query, params) do
@@ -43,9 +40,6 @@ defmodule Algoliax.Resources.Search do
         body: body
       })
     end)
-    |> case do
-      [single_result] -> single_result
-      [_ | _] = multiple_result -> multiple_result
-    end
+    |> render_result()
   end
 end

--- a/lib/algoliax/responses.ex
+++ b/lib/algoliax/responses.ex
@@ -1,6 +1,6 @@
 defmodule Algoliax.Responses do
   @moduledoc """
-  Algolia API response
+  Algolia API responses
   """
 
   @type t :: %__MODULE__{

--- a/lib/algoliax/responses.ex
+++ b/lib/algoliax/responses.ex
@@ -1,0 +1,12 @@
+defmodule Algoliax.Responses do
+  @moduledoc """
+  Algolia API response
+  """
+
+  @type t :: %__MODULE__{
+          index_name: String.t(),
+          responses: list(Algoliax.Response)
+        }
+
+  defstruct [:index_name, :responses]
+end

--- a/lib/algoliax/temporary_indexer.ex
+++ b/lib/algoliax/temporary_indexer.ex
@@ -3,7 +3,7 @@ defmodule Algoliax.TemporaryIndexer do
   Execute save_object(s) on temporary index to keep it synchronized with main index
   """
 
-  import Algoliax.Utils, only: [index_name: 2, render_result: 1]
+  import Algoliax.Utils, only: [index_name: 2, render_response: 1]
 
   alias Algoliax.SettingsStore
   alias Algoliax.Resources.Object
@@ -24,7 +24,7 @@ defmodule Algoliax.TemporaryIndexer do
         execute(action, module, tmp_settings, models, opts)
       end
     end)
-    |> render_result()
+    |> render_response()
   end
 
   defp execute(:save_objects, module, settings, models, opts) do

--- a/lib/algoliax/temporary_indexer.ex
+++ b/lib/algoliax/temporary_indexer.ex
@@ -3,7 +3,7 @@ defmodule Algoliax.TemporaryIndexer do
   Execute save_object(s) on temporary index to keep it synchronized with main index
   """
 
-  import Algoliax.Utils, only: [index_name: 2]
+  import Algoliax.Utils, only: [index_name: 2, render_result: 1]
 
   alias Algoliax.SettingsStore
   alias Algoliax.Resources.Object
@@ -24,10 +24,7 @@ defmodule Algoliax.TemporaryIndexer do
         execute(action, module, tmp_settings, models, opts)
       end
     end)
-    |> case do
-      [single_result] -> single_result
-      [_ | _] = multiple_result -> multiple_result
-    end
+    |> render_result()
   end
 
   defp execute(:save_objects, module, settings, models, opts) do

--- a/lib/algoliax/temporary_indexer.ex
+++ b/lib/algoliax/temporary_indexer.ex
@@ -15,13 +15,18 @@ defmodule Algoliax.TemporaryIndexer do
   defp do_run(action, module, settings, models, opts) do
     opts = Keyword.delete(opts, :temporary_only)
 
-    index_name = index_name(module, settings)
+    index_name(module, settings)
+    |> Enum.map(fn index_name ->
+      if SettingsStore.reindexing?(index_name) do
+        tmp_index_name = :"#{index_name}.tmp"
+        tmp_settings = SettingsStore.get_settings(tmp_index_name)
 
-    if SettingsStore.reindexing?(index_name) do
-      tmp_index_name = :"#{index_name}.tmp"
-      tmp_settings = SettingsStore.get_settings(tmp_index_name)
-
-      execute(action, module, tmp_settings, models, opts)
+        execute(action, module, tmp_settings, models, opts)
+      end
+    end)
+    |> case do
+      [single_result] -> single_result
+      [_ | _] = multiple_result -> multiple_result
     end
   end
 

--- a/lib/algoliax/utils.ex
+++ b/lib/algoliax/utils.ex
@@ -54,4 +54,11 @@ defmodule Algoliax.Utils do
     |> Atom.to_string()
     |> Inflex.camelize(:lower)
   end
+
+  def render_result(result) do
+    case result do
+      [single_result] -> single_result
+      [_ | _] = multiple_result -> multiple_result
+    end
+  end
 end

--- a/lib/algoliax/utils.ex
+++ b/lib/algoliax/utils.ex
@@ -57,8 +57,33 @@ defmodule Algoliax.Utils do
 
   def render_result(result) do
     case result do
-      [single_result] -> single_result
-      [_ | _] = multiple_result -> multiple_result
+      [single_result] ->
+        single_result
+
+      [_ | _] = multiple_result ->
+        multiple_result
+        |> List.flatten()
+        |> Enum.reject(&is_nil/1)
+        |> case do
+          [{:ok, :completed} | _] = results ->
+            results
+
+          results ->
+            results =
+              results
+              |> Enum.group_by(fn
+                {:ok, %Algoliax.Response{params: params}} -> params[:index_name]
+                {:error, _, _, %{url_params: params}} -> params[:index_name]
+              end)
+              |> Enum.map(fn {index_name, results} ->
+                %Algoliax.Responses{
+                  index_name: index_name,
+                  responses: results
+                }
+              end)
+
+            {:ok, results}
+        end
     end
   end
 end

--- a/lib/algoliax/utils.ex
+++ b/lib/algoliax/utils.ex
@@ -25,7 +25,8 @@ defmodule Algoliax.Utils do
       end
 
     indexes
-    |> Enum.each(fn index -> Index.ensure_settings(module, index, settings) end)
+    |> Enum.with_index()
+    |> Enum.each(fn {index, i} -> Index.ensure_settings(module, index, settings, i) end)
 
     indexes
   end

--- a/priv/repo/migrations/20230525101211_create_people_with_association_multiple_indexes.exs
+++ b/priv/repo/migrations/20230525101211_create_people_with_association_multiple_indexes.exs
@@ -2,7 +2,7 @@ defmodule Algoliax.Repo.Migrations.CreatePeopleWithAssociationMultipleIndexes do
   use Ecto.Migration
 
   def change do
-    create table(:peoples_with_associations_multiple_indexes) do
+    create table(:people_with_associations_multiple_indexes) do
       add(:reference, :uuid)
       add(:first_name, :string)
       add(:last_name, :string)
@@ -14,7 +14,7 @@ defmodule Algoliax.Repo.Migrations.CreatePeopleWithAssociationMultipleIndexes do
 
     create table(:flowers) do
       add(:kind, :string)
-      add(:people_with_association_multiple_indexes_id, references(:peoples_with_associations_multiple_indexes))
+      add(:people_with_association_multiple_indexes_id, references(:people_with_associations_multiple_indexes))
 
       timestamps()
     end

--- a/priv/repo/migrations/20230525101211_create_people_with_association_multiple_indexes.exs
+++ b/priv/repo/migrations/20230525101211_create_people_with_association_multiple_indexes.exs
@@ -1,0 +1,22 @@
+defmodule Algoliax.Repo.Migrations.CreatePeopleWithAssociationMultipleIndexes do
+  use Ecto.Migration
+
+  def change do
+    create table(:peoples_with_associations_multiple_indexes) do
+      add(:reference, :uuid)
+      add(:first_name, :string)
+      add(:last_name, :string)
+      add(:age, :integer)
+      add(:gender, :string)
+
+      timestamps()
+    end
+
+    create table(:flowers) do
+      add(:kind, :string)
+      add(:people_with_association_multiple_indexes_id, references(:peoples_with_associations_multiple_indexes))
+
+      timestamps()
+    end
+  end
+end

--- a/test/algoliax/replica_test.exs
+++ b/test/algoliax/replica_test.exs
@@ -35,7 +35,7 @@ defmodule AlgoliaxTest.ReplicaTest do
     end
 
     test "save_object/1" do
-      reference = :random.uniform(1_000_000) |> to_string()
+      reference = :rand.uniform(1_000_000) |> to_string()
 
       person = %PeopleWithReplicas{
         reference: reference,
@@ -62,8 +62,8 @@ defmodule AlgoliaxTest.ReplicaTest do
     end
 
     test "save_objects/1" do
-      reference1 = :random.uniform(1_000_000) |> to_string()
-      reference2 = :random.uniform(1_000_000) |> to_string()
+      reference1 = :rand.uniform(1_000_000) |> to_string()
+      reference2 = :rand.uniform(1_000_000) |> to_string()
 
       people = [
         %PeopleWithReplicas{reference: reference1, last_name: "Doe", first_name: "John", age: 77},

--- a/test/algoliax/replica_test.exs
+++ b/test/algoliax/replica_test.exs
@@ -50,8 +50,6 @@ defmodule AlgoliaxTest.ReplicaTest do
                params: [index_name: :algoliax_people_replicas_fr]
              } = res2
 
-      # TODO: MATCHER LE REPLICA AVEC L'INDEX PRINCIPAL ASSOCIÉ POUR PAS DUPLIQUER LES REPLICAS AVEC LES MÊMES NOMS
-
       assert_request("PUT", ~r/algoliax_people_replicas_en/, %{
         "searchableAttributes" => ["full_name"],
         "attributesForFaceting" => ["age"],
@@ -116,6 +114,49 @@ defmodule AlgoliaxTest.ReplicaTest do
       })
     end
 
+    test "save_object/1 with multiple indexes" do
+      reference = :rand.uniform(1_000_000) |> to_string()
+
+      person = %PeopleWithReplicasMultipleIndexes{
+        reference: reference,
+        last_name: "Doe",
+        first_name: "John",
+        age: 77
+      }
+
+      assert [{:ok, res}, {:ok, res2}] = PeopleWithReplicasMultipleIndexes.save_object(person)
+
+      assert %Algoliax.Response{
+               response: %{"taskID" => _, "updatedAt" => _, "objectID" => ^reference},
+               params: [index_name: :algoliax_people_replicas_en, object_id: ^reference]
+             } = res
+
+      assert %Algoliax.Response{
+               response: %{"taskID" => _, "updatedAt" => _, "objectID" => ^reference},
+               params: [index_name: :algoliax_people_replicas_fr, object_id: ^reference]
+             } = res2
+
+      assert_request("PUT", ~r/algoliax_people_replicas_en/, %{
+        "age" => 77,
+        "first_name" => "John",
+        "full_name" => "John Doe",
+        "last_name" => "Doe",
+        "nickname" => "john",
+        "objectID" => reference,
+        "updated_at" => 1_546_300_800
+      })
+
+      assert_request("PUT", ~r/algoliax_people_replicas_fr/, %{
+        "age" => 77,
+        "first_name" => "John",
+        "full_name" => "John Doe",
+        "last_name" => "Doe",
+        "nickname" => "john",
+        "objectID" => reference,
+        "updated_at" => 1_546_300_800
+      })
+    end
+
     test "save_objects/1" do
       reference1 = :rand.uniform(1_000_000) |> to_string()
       reference2 = :rand.uniform(1_000_000) |> to_string()
@@ -142,7 +183,59 @@ defmodule AlgoliaxTest.ReplicaTest do
       })
     end
 
-    test "get_object/1" do
+    test "save_objects/1 with multiple indexes" do
+      reference1 = :rand.uniform(1_000_000) |> to_string()
+      reference2 = :rand.uniform(1_000_000) |> to_string()
+
+      people = [
+        %PeopleWithReplicasMultipleIndexes{
+          reference: reference1,
+          last_name: "Doe",
+          first_name: "John",
+          age: 77
+        },
+        %PeopleWithReplicasMultipleIndexes{
+          reference: reference2,
+          last_name: "al",
+          first_name: "bert",
+          age: 35
+        }
+      ]
+
+      assert [{:ok, res}, {:ok, res2}] = PeopleWithReplicasMultipleIndexes.save_objects(people)
+
+      assert %Algoliax.Response{
+               response: %{
+                 "taskID" => _,
+                 "objectIDs" => [^reference1, ^reference2]
+               },
+               params: [index_name: :algoliax_people_replicas_en]
+             } = res
+
+      assert %Algoliax.Response{
+               response: %{
+                 "taskID" => _,
+                 "objectIDs" => [^reference1, ^reference2]
+               },
+               params: [index_name: :algoliax_people_replicas_fr]
+             } = res2
+
+      assert_request("POST", ~r/algoliax_people_replicas_en/, %{
+        "requests" => [
+          %{"action" => "updateObject", "body" => %{"objectID" => reference1}},
+          %{"action" => "updateObject", "body" => %{"objectID" => reference2}}
+        ]
+      })
+
+      assert_request("POST", ~r/algoliax_people_replicas_fr/, %{
+        "requests" => [
+          %{"action" => "updateObject", "body" => %{"objectID" => reference1}},
+          %{"action" => "updateObject", "body" => %{"objectID" => reference2}}
+        ]
+      })
+    end
+
+    test "get_object/1 " do
       person = %PeopleWithReplicas{
         reference: "known",
         last_name: "Doe",
@@ -155,6 +248,30 @@ defmodule AlgoliaxTest.ReplicaTest do
       assert_request("GET", %{})
     end
 
+    test "get_object/1 with multiple indexes" do
+      person = %PeopleWithReplicasMultipleIndexes{
+        reference: "known",
+        last_name: "Doe",
+        first_name: "John",
+        age: 77
+      }
+
+      assert [{:ok, res}, {:ok, res2}] = PeopleWithReplicasMultipleIndexes.get_object(person)
+
+      assert %Algoliax.Response{
+               response: %{"objectID" => "known"},
+               params: [index_name: :algoliax_people_replicas_en, object_id: "known"]
+             } = res
+
+      assert %Algoliax.Response{
+               response: %{"objectID" => "known"},
+               params: [index_name: :algoliax_people_replicas_fr, object_id: "known"]
+             } = res2
+
+      assert_request("GET", ~r/algoliax_people_replicas_en/, %{})
+      assert_request("GET", ~r/algoliax_people_replicas_fr/, %{})
+    end
+
     test "get_object/1 w/ unknown" do
       person = %PeopleWithReplicas{
         reference: "unknown",
@@ -164,6 +281,21 @@ defmodule AlgoliaxTest.ReplicaTest do
       }
 
       assert {:error, 404, _} = PeopleWithReplicas.get_object(person)
+    end
+
+    test "get_object/1 w/ unknown & multiple indexes" do
+      person = %PeopleWithReplicasMultipleIndexes{
+        reference: "unknown",
+        last_name: "Doe",
+        first_name: "John",
+        age: 77
+      }
+
+      assert [{:error, 404, _}, {:error, 404, _}] =
+               PeopleWithReplicasMultipleIndexes.get_object(person)
+
+      assert_request("GET", ~r/algoliax_people_replicas_en/, %{})
+      assert_request("GET", ~r/algoliax_people_replicas_fr/, %{})
     end
 
     test "delete_object/1" do
@@ -178,9 +310,28 @@ defmodule AlgoliaxTest.ReplicaTest do
       assert_request("DELETE", %{})
     end
 
+    test "delete_object/1 with multiple indexes" do
+      person = %PeopleWithReplicasMultipleIndexes{
+        reference: "unknown",
+        last_name: "Doe",
+        first_name: "John",
+        age: 77
+      }
+
+      assert [{:ok, _}, {:ok, _}] = PeopleWithReplicasMultipleIndexes.delete_object(person)
+      assert_request("DELETE", ~r/algoliax_people_replicas_en/, %{})
+      assert_request("DELETE", ~r/algoliax_people_replicas_fr/, %{})
+    end
+
     test "delete_index/0" do
       assert {:ok, _} = PeopleWithReplicas.delete_index()
       assert_request("DELETE", %{})
+    end
+
+    test "delete_index/0 with multiple indexes" do
+      assert [{:ok, _}, {:ok, _}] = PeopleWithReplicasMultipleIndexes.delete_index()
+      assert_request("DELETE", ~r/algoliax_people_replicas_en/, %{})
+      assert_request("DELETE", ~r/algoliax_people_replicas_fr/, %{})
     end
 
     test "get_settings/0" do
@@ -189,14 +340,52 @@ defmodule AlgoliaxTest.ReplicaTest do
       assert_request("GET", %{})
     end
 
+    test "get_settings/0 with multiple indexes" do
+      assert [{:ok, res}, {:ok, res2}] = PeopleWithReplicasMultipleIndexes.get_settings()
+
+      assert %Algoliax.Response{
+               response: %{"searchableAttributes" => ["test"]},
+               params: [index_name: :algoliax_people_replicas_en]
+             } = res
+
+      assert %Algoliax.Response{
+               response: %{"searchableAttributes" => ["test"]},
+               params: [index_name: :algoliax_people_replicas_fr]
+             } = res2
+
+      assert_request("GET", ~r/algoliax_people_replicas_en/, %{})
+      assert_request("GET", ~r/algoliax_people_replicas_fr/, %{})
+    end
+
     test "search/2" do
       assert {:ok, _} = PeopleWithReplicas.search("john", %{hitsPerPage: 10})
       assert_request("POST", %{"query" => "john", "hitsPerPage" => 10})
     end
 
+    test "search/2 with multiple indexes" do
+      assert [{:ok, _}, {:ok, _}] =
+               PeopleWithReplicasMultipleIndexes.search("john", %{hitsPerPage: 10})
+
+      assert_request("POST", ~r/algoliax_people_replicas_en/, %{
+        "query" => "john",
+        "hitsPerPage" => 10
+      })
+
+      assert_request("POST", ~r/algoliax_people_replicas_fr/, %{
+        "query" => "john",
+        "hitsPerPage" => 10
+      })
+    end
+
     test "search_facet/2" do
       assert {:ok, _} = PeopleWithReplicas.search_facet("age", "2")
       assert_request("POST", %{"facetQuery" => "2"})
+    end
+
+    test "search_facet/2 with multiple indexes" do
+      assert [{:ok, _}, {:ok, _}] = PeopleWithReplicasMultipleIndexes.search_facet("age", "2")
+      assert_request("POST", ~r/algoliax_people_replicas_en/, %{"facetQuery" => "2"})
+      assert_request("POST", ~r/algoliax_people_replicas_fr/, %{"facetQuery" => "2"})
     end
   end
 end

--- a/test/algoliax/replica_test.exs
+++ b/test/algoliax/replica_test.exs
@@ -38,16 +38,28 @@ defmodule AlgoliaxTest.ReplicaTest do
     end
 
     test "configure_index/0 with multiple indexes" do
-      assert [{:ok, res}, {:ok, res2}] = PeopleWithReplicasMultipleIndexes.configure_index()
+      assert {:ok, [res, res2]} = PeopleWithReplicasMultipleIndexes.configure_index()
 
-      assert %Algoliax.Response{
-               response: %{"taskID" => _, "updatedAt" => _},
-               params: [index_name: :algoliax_people_replicas_en]
+      assert %Algoliax.Responses{
+               index_name: :algoliax_people_replicas_en,
+               responses: [
+                 {:ok,
+                  %Algoliax.Response{
+                    response: %{"taskID" => _, "updatedAt" => _},
+                    params: [index_name: :algoliax_people_replicas_en]
+                  }}
+               ]
              } = res
 
-      assert %Algoliax.Response{
-               response: %{"taskID" => _, "updatedAt" => _},
-               params: [index_name: :algoliax_people_replicas_fr]
+      assert %Algoliax.Responses{
+               index_name: :algoliax_people_replicas_fr,
+               responses: [
+                 {:ok,
+                  %Algoliax.Response{
+                    response: %{"taskID" => _, "updatedAt" => _},
+                    params: [index_name: :algoliax_people_replicas_fr]
+                  }}
+               ]
              } = res2
 
       assert_request("PUT", ~r/algoliax_people_replicas_en/, %{
@@ -124,16 +136,28 @@ defmodule AlgoliaxTest.ReplicaTest do
         age: 77
       }
 
-      assert [{:ok, res}, {:ok, res2}] = PeopleWithReplicasMultipleIndexes.save_object(person)
+      assert {:ok, [res, res2]} = PeopleWithReplicasMultipleIndexes.save_object(person)
 
-      assert %Algoliax.Response{
-               response: %{"taskID" => _, "updatedAt" => _, "objectID" => ^reference},
-               params: [index_name: :algoliax_people_replicas_en, object_id: ^reference]
+      assert %Algoliax.Responses{
+               index_name: :algoliax_people_replicas_en,
+               responses: [
+                 {:ok,
+                  %Algoliax.Response{
+                    response: %{"taskID" => _, "updatedAt" => _, "objectID" => ^reference},
+                    params: [index_name: :algoliax_people_replicas_en, object_id: ^reference]
+                  }}
+               ]
              } = res
 
-      assert %Algoliax.Response{
-               response: %{"taskID" => _, "updatedAt" => _, "objectID" => ^reference},
-               params: [index_name: :algoliax_people_replicas_fr, object_id: ^reference]
+      assert %Algoliax.Responses{
+               index_name: :algoliax_people_replicas_fr,
+               responses: [
+                 {:ok,
+                  %Algoliax.Response{
+                    response: %{"taskID" => _, "updatedAt" => _, "objectID" => ^reference},
+                    params: [index_name: :algoliax_people_replicas_fr, object_id: ^reference]
+                  }}
+               ]
              } = res2
 
       assert_request("PUT", ~r/algoliax_people_replicas_en/, %{
@@ -202,22 +226,34 @@ defmodule AlgoliaxTest.ReplicaTest do
         }
       ]
 
-      assert [{:ok, res}, {:ok, res2}] = PeopleWithReplicasMultipleIndexes.save_objects(people)
+      assert {:ok, [res, res2]} = PeopleWithReplicasMultipleIndexes.save_objects(people)
 
-      assert %Algoliax.Response{
-               response: %{
-                 "taskID" => _,
-                 "objectIDs" => [^reference1, ^reference2]
-               },
-               params: [index_name: :algoliax_people_replicas_en]
+      assert %Algoliax.Responses{
+               index_name: :algoliax_people_replicas_en,
+               responses: [
+                 {:ok,
+                  %Algoliax.Response{
+                    response: %{
+                      "taskID" => _,
+                      "objectIDs" => [^reference1, ^reference2]
+                    },
+                    params: [index_name: :algoliax_people_replicas_en]
+                  }}
+               ]
              } = res
 
-      assert %Algoliax.Response{
-               response: %{
-                 "taskID" => _,
-                 "objectIDs" => [^reference1, ^reference2]
-               },
-               params: [index_name: :algoliax_people_replicas_fr]
+      assert %Algoliax.Responses{
+               index_name: :algoliax_people_replicas_fr,
+               responses: [
+                 {:ok,
+                  %Algoliax.Response{
+                    response: %{
+                      "taskID" => _,
+                      "objectIDs" => [^reference1, ^reference2]
+                    },
+                    params: [index_name: :algoliax_people_replicas_fr]
+                  }}
+               ]
              } = res2
 
       assert_request("POST", ~r/algoliax_people_replicas_en/, %{
@@ -256,16 +292,28 @@ defmodule AlgoliaxTest.ReplicaTest do
         age: 77
       }
 
-      assert [{:ok, res}, {:ok, res2}] = PeopleWithReplicasMultipleIndexes.get_object(person)
+      assert {:ok, [res, res2]} = PeopleWithReplicasMultipleIndexes.get_object(person)
 
-      assert %Algoliax.Response{
-               response: %{"objectID" => "known"},
-               params: [index_name: :algoliax_people_replicas_en, object_id: "known"]
+      assert %Algoliax.Responses{
+               index_name: :algoliax_people_replicas_en,
+               responses: [
+                 {:ok,
+                  %Algoliax.Response{
+                    response: %{"objectID" => "known"},
+                    params: [index_name: :algoliax_people_replicas_en, object_id: "known"]
+                  }}
+               ]
              } = res
 
-      assert %Algoliax.Response{
-               response: %{"objectID" => "known"},
-               params: [index_name: :algoliax_people_replicas_fr, object_id: "known"]
+      assert %Algoliax.Responses{
+               index_name: :algoliax_people_replicas_fr,
+               responses: [
+                 {:ok,
+                  %Algoliax.Response{
+                    response: %{"objectID" => "known"},
+                    params: [index_name: :algoliax_people_replicas_fr, object_id: "known"]
+                  }}
+               ]
              } = res2
 
       assert_request("GET", ~r/algoliax_people_replicas_en/, %{})
@@ -280,7 +328,7 @@ defmodule AlgoliaxTest.ReplicaTest do
         age: 77
       }
 
-      assert {:error, 404, _} = PeopleWithReplicas.get_object(person)
+      assert {:error, 404, _, _} = PeopleWithReplicas.get_object(person)
     end
 
     test "get_object/1 w/ unknown & multiple indexes" do
@@ -291,8 +339,17 @@ defmodule AlgoliaxTest.ReplicaTest do
         age: 77
       }
 
-      assert [{:error, 404, _}, {:error, 404, _}] =
-               PeopleWithReplicasMultipleIndexes.get_object(person)
+      assert {:ok,
+              [
+                %Algoliax.Responses{
+                  index_name: :algoliax_people_replicas_en,
+                  responses: [{:error, 404, "{}", _}]
+                },
+                %Algoliax.Responses{
+                  index_name: :algoliax_people_replicas_fr,
+                  responses: [{:error, 404, "{}", _}]
+                }
+              ]} = PeopleWithReplicasMultipleIndexes.get_object(person)
 
       assert_request("GET", ~r/algoliax_people_replicas_en/, %{})
       assert_request("GET", ~r/algoliax_people_replicas_fr/, %{})
@@ -318,7 +375,12 @@ defmodule AlgoliaxTest.ReplicaTest do
         age: 77
       }
 
-      assert [{:ok, _}, {:ok, _}] = PeopleWithReplicasMultipleIndexes.delete_object(person)
+      assert {:ok,
+              [
+                %Algoliax.Responses{index_name: :algoliax_people_replicas_en},
+                %Algoliax.Responses{index_name: :algoliax_people_replicas_fr}
+              ]} = PeopleWithReplicasMultipleIndexes.delete_object(person)
+
       assert_request("DELETE", ~r/algoliax_people_replicas_en/, %{})
       assert_request("DELETE", ~r/algoliax_people_replicas_fr/, %{})
     end
@@ -329,7 +391,12 @@ defmodule AlgoliaxTest.ReplicaTest do
     end
 
     test "delete_index/0 with multiple indexes" do
-      assert [{:ok, _}, {:ok, _}] = PeopleWithReplicasMultipleIndexes.delete_index()
+      assert {:ok,
+              [
+                %Algoliax.Responses{index_name: :algoliax_people_replicas_en},
+                %Algoliax.Responses{index_name: :algoliax_people_replicas_fr}
+              ]} = PeopleWithReplicasMultipleIndexes.delete_index()
+
       assert_request("DELETE", ~r/algoliax_people_replicas_en/, %{})
       assert_request("DELETE", ~r/algoliax_people_replicas_fr/, %{})
     end
@@ -341,16 +408,28 @@ defmodule AlgoliaxTest.ReplicaTest do
     end
 
     test "get_settings/0 with multiple indexes" do
-      assert [{:ok, res}, {:ok, res2}] = PeopleWithReplicasMultipleIndexes.get_settings()
+      assert {:ok, [res, res2]} = PeopleWithReplicasMultipleIndexes.get_settings()
 
-      assert %Algoliax.Response{
-               response: %{"searchableAttributes" => ["test"]},
-               params: [index_name: :algoliax_people_replicas_en]
+      assert %Algoliax.Responses{
+               index_name: :algoliax_people_replicas_en,
+               responses: [
+                 {:ok,
+                  %Algoliax.Response{
+                    response: %{"searchableAttributes" => ["test"]},
+                    params: [index_name: :algoliax_people_replicas_en]
+                  }}
+               ]
              } = res
 
-      assert %Algoliax.Response{
-               response: %{"searchableAttributes" => ["test"]},
-               params: [index_name: :algoliax_people_replicas_fr]
+      assert %Algoliax.Responses{
+               index_name: :algoliax_people_replicas_fr,
+               responses: [
+                 {:ok,
+                  %Algoliax.Response{
+                    response: %{"searchableAttributes" => ["test"]},
+                    params: [index_name: :algoliax_people_replicas_fr]
+                  }}
+               ]
              } = res2
 
       assert_request("GET", ~r/algoliax_people_replicas_en/, %{})
@@ -363,8 +442,11 @@ defmodule AlgoliaxTest.ReplicaTest do
     end
 
     test "search/2 with multiple indexes" do
-      assert [{:ok, _}, {:ok, _}] =
-               PeopleWithReplicasMultipleIndexes.search("john", %{hitsPerPage: 10})
+      assert {:ok,
+              [
+                %Algoliax.Responses{index_name: :algoliax_people_replicas_en},
+                %Algoliax.Responses{index_name: :algoliax_people_replicas_fr}
+              ]} = PeopleWithReplicasMultipleIndexes.search("john", %{hitsPerPage: 10})
 
       assert_request("POST", ~r/algoliax_people_replicas_en/, %{
         "query" => "john",
@@ -383,7 +465,12 @@ defmodule AlgoliaxTest.ReplicaTest do
     end
 
     test "search_facet/2 with multiple indexes" do
-      assert [{:ok, _}, {:ok, _}] = PeopleWithReplicasMultipleIndexes.search_facet("age", "2")
+      assert {:ok,
+              [
+                %Algoliax.Responses{index_name: :algoliax_people_replicas_en},
+                %Algoliax.Responses{index_name: :algoliax_people_replicas_fr}
+              ]} = PeopleWithReplicasMultipleIndexes.search_facet("age", "2")
+
       assert_request("POST", ~r/algoliax_people_replicas_en/, %{"facetQuery" => "2"})
       assert_request("POST", ~r/algoliax_people_replicas_fr/, %{"facetQuery" => "2"})
     end

--- a/test/algoliax/schema_test.exs
+++ b/test/algoliax/schema_test.exs
@@ -14,12 +14,19 @@ defmodule AlgoliaxTest.Schema do
   alias Algoliax.Schemas.{
     Animal,
     Beer,
+    Flower,
     PeopleEcto,
+    PeopleEctoMultipleIndexes,
     PeopleEctoFail,
+    PeopleEctoFailMultipleIndexes,
     PeopleWithoutIdEcto,
+    PeopleWithoutIdEctoMultipleIndexes,
     PeopleWithSchemas,
+    PeopleWithSchemasMultipleIndexes,
     PeopleWithAssociation,
-    PeopleWithCustomObjectId
+    PeopleWithAssociationMultipleIndexes,
+    PeopleWithCustomObjectId,
+    PeopleWithCustomObjectIdMultipleIndexes
   }
 
   @ref1 Ecto.UUID.generate()
@@ -30,8 +37,18 @@ defmodule AlgoliaxTest.Schema do
     Algoliax.SettingsStore.set_settings(:algoliax_people, %{})
     Algoliax.SettingsStore.set_settings(:"algoliax_people.tmp", %{})
 
+    Algoliax.SettingsStore.set_settings(:algoliax_people_en, %{})
+    Algoliax.SettingsStore.set_settings(:"algoliax_people_en.tmp", %{})
+    Algoliax.SettingsStore.set_settings(:algoliax_people_fr, %{})
+    Algoliax.SettingsStore.set_settings(:"algoliax_people_fr.tmp", %{})
+
     Algoliax.SettingsStore.set_settings(:algoliax_people_fail, %{})
     Algoliax.SettingsStore.set_settings(:"algoliax_people_fail.tmp", %{})
+
+    Algoliax.SettingsStore.set_settings(:algoliax_people_fail_en, %{})
+    Algoliax.SettingsStore.set_settings(:"algoliax_people_fail_en.tmp", %{})
+    Algoliax.SettingsStore.set_settings(:algoliax_people_fail_fr, %{})
+    Algoliax.SettingsStore.set_settings(:"algoliax_people_fail_fr.tmp", %{})
 
     Algoliax.SettingsStore.set_settings(:algoliax_people_without_id, %{})
     Algoliax.SettingsStore.set_settings(:"algoliax_people_without_id.tmp", %{})
@@ -120,6 +137,33 @@ defmodule AlgoliaxTest.Schema do
         first_name: "Dark",
         age: 9,
         animals: [%Animal{kind: "dog"}]
+      },
+      %PeopleWithAssociationMultipleIndexes{
+        reference: @ref1,
+        last_name: "Doe",
+        first_name: "John",
+        age: 77,
+        flowers: [%Flower{kind: "rose"}, %Flower{kind: "lily"}]
+      },
+      %PeopleWithAssociationMultipleIndexes{
+        reference: @ref1,
+        last_name: "Einstein",
+        first_name: "Alber",
+        age: 22,
+        flowers: [%Flower{kind: "rose"}, %Flower{kind: "lily"}, %Flower{kind: "orchid"}]
+      },
+      %PeopleWithAssociationMultipleIndexes{
+        reference: @ref2,
+        last_name: "al",
+        first_name: "bert",
+        age: 35
+      },
+      %PeopleWithAssociationMultipleIndexes{
+        reference: @ref3,
+        last_name: "Vador",
+        first_name: "Dark",
+        age: 9,
+        flowers: [%Flower{kind: "orchid"}]
       }
     ]
     |> Enum.each(fn p ->
@@ -164,6 +208,70 @@ defmodule AlgoliaxTest.Schema do
     })
   end
 
+  test "reindex multiple indexes" do
+    assert {:ok,
+            [
+              [{:ok, %Algoliax.Response{}}, {:ok, %Algoliax.Response{}}],
+              [{:ok, %Algoliax.Response{}}, {:ok, %Algoliax.Response{}}]
+            ]} = PeopleEctoMultipleIndexes.reindex()
+
+    assert_request("POST", ~r/algoliax_people_en/, %{
+      "requests" => [
+        %{
+          "action" => "updateObject",
+          "body" => %{
+            "objectID" => @ref1,
+            "last_name" => "Doe",
+            "first_name" => "John",
+            "age" => 77
+          }
+        }
+      ]
+    })
+
+    assert_request("POST", ~r/algoliax_people_en/, %{
+      "requests" => [
+        %{
+          "action" => "updateObject",
+          "body" => %{
+            "objectID" => @ref2,
+            "last_name" => "al",
+            "first_name" => "bert",
+            "age" => 35
+          }
+        }
+      ]
+    })
+
+    assert_request("POST", ~r/algoliax_people_fr/, %{
+      "requests" => [
+        %{
+          "action" => "updateObject",
+          "body" => %{
+            "objectID" => @ref1,
+            "last_name" => "Doe",
+            "first_name" => "John",
+            "age" => 77
+          }
+        }
+      ]
+    })
+
+    assert_request("POST", ~r/algoliax_people_fr/, %{
+      "requests" => [
+        %{
+          "action" => "updateObject",
+          "body" => %{
+            "objectID" => @ref2,
+            "last_name" => "al",
+            "first_name" => "bert",
+            "age" => 35
+          }
+        }
+      ]
+    })
+  end
+
   test "reindex with force delete" do
     assert {:ok,
             [
@@ -191,6 +299,60 @@ defmodule AlgoliaxTest.Schema do
     })
   end
 
+  test "reindex multiple indexes with force delete" do
+    assert {:ok,
+            [
+              [
+                {:ok, %Algoliax.Response{}},
+                {:ok, %Algoliax.Response{}}
+              ],
+              [
+                {:ok, %Algoliax.Response{}},
+                {:ok, %Algoliax.Response{}}
+              ],
+              [
+                {:ok, %Algoliax.Response{}},
+                {:ok, %Algoliax.Response{}}
+              ]
+            ]} = PeopleEctoMultipleIndexes.reindex(force_delete: true)
+
+    assert_request("POST", ~r/algoliax_people_en/, %{
+      "requests" => [
+        %{"action" => "updateObject", "body" => %{"objectID" => @ref1}}
+      ]
+    })
+
+    assert_request("POST", ~r/algoliax_people_en/, %{
+      "requests" => [
+        %{"action" => "updateObject", "body" => %{"objectID" => @ref2}}
+      ]
+    })
+
+    assert_request("POST", ~r/algoliax_people_en/, %{
+      "requests" => [
+        %{"action" => "deleteObject", "body" => %{"objectID" => @ref3}}
+      ]
+    })
+
+    assert_request("POST", ~r/algoliax_people_fr/, %{
+      "requests" => [
+        %{"action" => "updateObject", "body" => %{"objectID" => @ref1}}
+      ]
+    })
+
+    assert_request("POST", ~r/algoliax_people_fr/, %{
+      "requests" => [
+        %{"action" => "updateObject", "body" => %{"objectID" => @ref2}}
+      ]
+    })
+
+    assert_request("POST", ~r/algoliax_people_fr/, %{
+      "requests" => [
+        %{"action" => "deleteObject", "body" => %{"objectID" => @ref3}}
+      ]
+    })
+  end
+
   test "reindex with query" do
     query =
       from(p in PeopleEcto,
@@ -200,6 +362,28 @@ defmodule AlgoliaxTest.Schema do
     assert {:ok, [{:ok, %Algoliax.Response{}}]} = PeopleEcto.reindex(query)
 
     assert_request("POST", %{
+      "requests" => [
+        %{"action" => "updateObject", "body" => %{"objectID" => @ref2}}
+      ]
+    })
+  end
+
+  test "reindex multiple indexes with query" do
+    query =
+      from(p in PeopleEctoMultipleIndexes,
+        where: p.age == 35
+      )
+
+    assert {:ok, [[{:ok, %Algoliax.Response{}}, {:ok, %Algoliax.Response{}}]]} =
+             PeopleEctoMultipleIndexes.reindex(query)
+
+    assert_request("POST", ~r/algoliax_people_en/, %{
+      "requests" => [
+        %{"action" => "updateObject", "body" => %{"objectID" => @ref2}}
+      ]
+    })
+
+    assert_request("POST", ~r/algoliax_people_fr/, %{
       "requests" => [
         %{"action" => "updateObject", "body" => %{"objectID" => @ref2}}
       ]
@@ -231,6 +415,49 @@ defmodule AlgoliaxTest.Schema do
     })
   end
 
+  test "reindex multiple indexes with query and force delete" do
+    query =
+      from(p in PeopleEctoMultipleIndexes,
+        where: p.age == 35 or p.first_name == "Dark"
+      )
+
+    assert {:ok,
+            [
+              [
+                {:ok, %Algoliax.Response{}},
+                {:ok, %Algoliax.Response{}}
+              ],
+              [
+                {:ok, %Algoliax.Response{}},
+                {:ok, %Algoliax.Response{}}
+              ]
+            ]} = PeopleEctoMultipleIndexes.reindex(query, force_delete: true)
+
+    assert_request("POST", ~r/algoliax_people_en/, %{
+      "requests" => [
+        %{"action" => "updateObject", "body" => %{"objectID" => @ref2}}
+      ]
+    })
+
+    assert_request("POST", ~r/algoliax_people_fr/, %{
+      "requests" => [
+        %{"action" => "updateObject", "body" => %{"objectID" => @ref2}}
+      ]
+    })
+
+    assert_request("POST", ~r/algoliax_people_en/, %{
+      "requests" => [
+        %{"action" => "deleteObject", "body" => %{"objectID" => @ref3}}
+      ]
+    })
+
+    assert_request("POST", ~r/algoliax_people_fr/, %{
+      "requests" => [
+        %{"action" => "deleteObject", "body" => %{"objectID" => @ref3}}
+      ]
+    })
+  end
+
   test "reindex atomic" do
     assert {:ok, :completed} = PeopleEcto.reindex_atomic()
 
@@ -252,6 +479,44 @@ defmodule AlgoliaxTest.Schema do
     })
   end
 
+  test "reindex multiple indeixes atomic" do
+    assert [{:ok, :completed}, {:ok, :completed}] = PeopleEctoMultipleIndexes.reindex_atomic()
+
+    assert_request("POST", ~r/algoliax_people_en/, %{
+      "requests" => [
+        %{"action" => "updateObject", "body" => %{"objectID" => @ref1}}
+      ]
+    })
+
+    assert_request("POST", ~r/algoliax_people_fr/, %{
+      "requests" => [
+        %{"action" => "updateObject", "body" => %{"objectID" => @ref1}}
+      ]
+    })
+
+    assert_request("POST", ~r/algoliax_people_en/, %{
+      "requests" => [
+        %{"action" => "updateObject", "body" => %{"objectID" => @ref2}}
+      ]
+    })
+
+    assert_request("POST", ~r/algoliax_people_fr/, %{
+      "requests" => [
+        %{"action" => "updateObject", "body" => %{"objectID" => @ref2}}
+      ]
+    })
+
+    assert_request("POST", ~r/algoliax_people_en\.tmp/, %{
+      "destination" => "algoliax_people_en",
+      "operation" => "move"
+    })
+
+    assert_request("POST", ~r/algoliax_people_fr\.tmp/, %{
+      "destination" => "algoliax_people_fr",
+      "operation" => "move"
+    })
+  end
+
   test "reindex atomic with fail" do
     assert_raise Postgrex.Error, fn ->
       PeopleEctoFail.reindex_atomic()
@@ -259,6 +524,16 @@ defmodule AlgoliaxTest.Schema do
 
     assert_request("DELETE", ~r/algoliax_people_fail\.tmp/, %{})
     refute Algoliax.SettingsStore.reindexing?(:algoliax_people_fail)
+  end
+
+  test "reindex multiple indexes atomic with fail" do
+    assert_raise Postgrex.Error, fn ->
+      PeopleEctoFailMultipleIndexes.reindex_atomic()
+    end
+
+    assert_request("DELETE", ~r/algoliax_people_fail_en\.tmp/, %{})
+    refute Algoliax.SettingsStore.reindexing?(:algoliax_people_fail_en)
+    refute Algoliax.SettingsStore.reindexing?(:algoliax_people_fail_fr)
   end
 
   test "reindex without an id column" do
@@ -288,10 +563,83 @@ defmodule AlgoliaxTest.Schema do
     })
   end
 
+  test "reindex multiple indexes without an id column" do
+    assert {:ok,
+            [
+              [
+                {:ok, %Algoliax.Response{}},
+                {:ok, %Algoliax.Response{}}
+              ],
+              [
+                {:ok, %Algoliax.Response{}},
+                {:ok, %Algoliax.Response{}}
+              ],
+              [
+                {:ok, %Algoliax.Response{}},
+                {:ok, %Algoliax.Response{}}
+              ]
+            ]} = PeopleWithoutIdEctoMultipleIndexes.reindex()
+
+    assert_request("POST", ~r/algoliax_people_without_id_en/, %{
+      "requests" => [
+        %{"action" => "updateObject", "body" => %{"objectID" => @ref1}}
+      ]
+    })
+
+    assert_request("POST", ~r/algoliax_people_without_id_en/, %{
+      "requests" => [
+        %{"action" => "updateObject", "body" => %{"objectID" => @ref2}}
+      ]
+    })
+
+    assert_request("POST", ~r/algoliax_people_without_id_en/, %{
+      "requests" => [
+        %{"action" => "updateObject", "body" => %{"objectID" => @ref3}}
+      ]
+    })
+
+    assert_request("POST", ~r/algoliax_people_without_id_fr/, %{
+      "requests" => [
+        %{"action" => "updateObject", "body" => %{"objectID" => @ref1}}
+      ]
+    })
+
+    assert_request("POST", ~r/algoliax_people_without_id_fr/, %{
+      "requests" => [
+        %{"action" => "updateObject", "body" => %{"objectID" => @ref2}}
+      ]
+    })
+
+    assert_request("POST", ~r/algoliax_people_without_id_fr/, %{
+      "requests" => [
+        %{"action" => "updateObject", "body" => %{"objectID" => @ref3}}
+      ]
+    })
+  end
+
   test "save_object/1 without attribute(s)" do
     assert {:ok, _} = PeopleWithSchemas.save_object(%Beer{kind: "brune", name: "chimay", id: 1})
 
     assert_request("PUT", %{
+      "name" => "chimay",
+      "objectID" => 1
+    })
+  end
+
+  test "save_object/1 without attribute(s) and multiple indexes" do
+    assert [{:ok, _}, {:ok, _}] =
+             PeopleWithSchemasMultipleIndexes.save_object(%Beer{
+               kind: "brune",
+               name: "chimay",
+               id: 1
+             })
+
+    assert_request("PUT", ~r/algoliax_with_schemas_en/, %{
+      "name" => "chimay",
+      "objectID" => 1
+    })
+
+    assert_request("PUT", ~r/algoliax_with_schemas_fr/, %{
       "name" => "chimay",
       "objectID" => 1
     })
@@ -313,6 +661,34 @@ defmodule AlgoliaxTest.Schema do
     })
   end
 
+  test "reindex/1 with schemas and multiple indexes" do
+    assert PeopleWithSchemasMultipleIndexes.reindex()
+
+    assert_request("POST", ~r/algoliax_with_schemas_en/, %{
+      "requests" => [
+        %{"action" => "updateObject", "body" => %{"name" => "chimay", "objectID" => 1}}
+      ]
+    })
+
+    assert_request("POST", ~r/algoliax_with_schemas_en/, %{
+      "requests" => [
+        %{"action" => "updateObject", "body" => %{"name" => "jupiler", "objectID" => 2}}
+      ]
+    })
+
+    assert_request("POST", ~r/algoliax_with_schemas_fr/, %{
+      "requests" => [
+        %{"action" => "updateObject", "body" => %{"name" => "chimay", "objectID" => 1}}
+      ]
+    })
+
+    assert_request("POST", ~r/algoliax_with_schemas_fr/, %{
+      "requests" => [
+        %{"action" => "updateObject", "body" => %{"name" => "jupiler", "objectID" => 2}}
+      ]
+    })
+  end
+
   test "reindex/1 with schemas and query" do
     query =
       from(b in Beer,
@@ -322,6 +698,27 @@ defmodule AlgoliaxTest.Schema do
     assert {:ok, _} = PeopleWithSchemas.reindex(query)
 
     assert_request("POST", %{
+      "requests" => [
+        %{"action" => "updateObject", "body" => %{"name" => "chimay", "objectID" => 1}}
+      ]
+    })
+  end
+
+  test "reindex/1 with schemas, query and multiple indexes" do
+    query =
+      from(b in Beer,
+        where: b.name == "chimay"
+      )
+
+    assert {:ok, [[{:ok, _}, {:ok, _}]]} = PeopleWithSchemasMultipleIndexes.reindex(query)
+
+    assert_request("POST", ~r/algoliax_with_schemas_en/, %{
+      "requests" => [
+        %{"action" => "updateObject", "body" => %{"name" => "chimay", "objectID" => 1}}
+      ]
+    })
+
+    assert_request("POST", ~r/algoliax_with_schemas_fr/, %{
       "requests" => [
         %{"action" => "updateObject", "body" => %{"name" => "chimay", "objectID" => 1}}
       ]
@@ -339,8 +736,29 @@ defmodule AlgoliaxTest.Schema do
     })
   end
 
+  test "reindex/1 with schemas, query as keyword list and multiple indexes" do
+    query = %{where: [name: "heineken"]}
+    assert {:ok, [[{:ok, _}, {:ok, _}]]} = PeopleWithSchemasMultipleIndexes.reindex(query)
+
+    assert_request("POST", ~r/algoliax_with_schemas_en/, %{
+      "requests" => [
+        %{"action" => "updateObject", "body" => %{"name" => "heineken", "objectID" => 3}}
+      ]
+    })
+
+    assert_request("POST", ~r/algoliax_with_schemas_fr/, %{
+      "requests" => [
+        %{"action" => "updateObject", "body" => %{"name" => "heineken", "objectID" => 3}}
+      ]
+    })
+  end
+
   test "reindex/1 with association" do
     assert {:ok, _} = PeopleWithAssociation.reindex()
+  end
+
+  test "reindex/1 with association and multiple indexes" do
+    assert {:ok, _} = PeopleWithAssociationMultipleIndexes.reindex()
   end
 
   describe "indexer w/ custom object id" do
@@ -371,6 +789,87 @@ defmodule AlgoliaxTest.Schema do
             "body" => %{
               "objectID" => "people-" <> @ref2,
               "last_name" => "al"
+            }
+          }
+        ]
+      })
+    end
+
+    test "reindex with multiple indexes" do
+      assert {:ok,
+              [
+                [{:ok, %Algoliax.Response{}}, {:ok, %Algoliax.Response{}}],
+                [{:ok, %Algoliax.Response{}}, {:ok, %Algoliax.Response{}}],
+                [{:ok, %Algoliax.Response{}}, {:ok, %Algoliax.Response{}}]
+              ]} = PeopleWithCustomObjectIdMultipleIndexes.reindex()
+
+      assert_request("POST", ~r/algoliax_people_with_custom_object_id_en/, %{
+        "requests" => [
+          %{
+            "action" => "updateObject",
+            "body" => %{
+              "objectID" => "people-" <> @ref1,
+              "last_name" => "Doe"
+            }
+          }
+        ]
+      })
+
+      assert_request("POST", ~r/algoliax_people_with_custom_object_id_fr/, %{
+        "requests" => [
+          %{
+            "action" => "updateObject",
+            "body" => %{
+              "objectID" => "people-" <> @ref1,
+              "last_name" => "Doe"
+            }
+          }
+        ]
+      })
+
+      assert_request("POST", ~r/algoliax_people_with_custom_object_id_en/, %{
+        "requests" => [
+          %{
+            "action" => "updateObject",
+            "body" => %{
+              "objectID" => "people-" <> @ref2,
+              "last_name" => "al"
+            }
+          }
+        ]
+      })
+
+      assert_request("POST", ~r/algoliax_people_with_custom_object_id_fr/, %{
+        "requests" => [
+          %{
+            "action" => "updateObject",
+            "body" => %{
+              "objectID" => "people-" <> @ref2,
+              "last_name" => "al"
+            }
+          }
+        ]
+      })
+
+      assert_request("POST", ~r/algoliax_people_with_custom_object_id_en/, %{
+        "requests" => [
+          %{
+            "action" => "updateObject",
+            "body" => %{
+              "objectID" => "people-" <> @ref3,
+              "last_name" => "Vador"
+            }
+          }
+        ]
+      })
+
+      assert_request("POST", ~r/algoliax_people_with_custom_object_id_fr/, %{
+        "requests" => [
+          %{
+            "action" => "updateObject",
+            "body" => %{
+              "objectID" => "people-" <> @ref3,
+              "last_name" => "Vador"
             }
           }
         ]

--- a/test/algoliax/schema_test.exs
+++ b/test/algoliax/schema_test.exs
@@ -211,8 +211,14 @@ defmodule AlgoliaxTest.Schema do
   test "reindex multiple indexes" do
     assert {:ok,
             [
-              [{:ok, %Algoliax.Response{}}, {:ok, %Algoliax.Response{}}],
-              [{:ok, %Algoliax.Response{}}, {:ok, %Algoliax.Response{}}]
+              %Algoliax.Responses{
+                index_name: :algoliax_people_en,
+                responses: [{:ok, %Algoliax.Response{}}, {:ok, %Algoliax.Response{}}]
+              },
+              %Algoliax.Responses{
+                index_name: :algoliax_people_fr,
+                responses: [{:ok, %Algoliax.Response{}}, {:ok, %Algoliax.Response{}}]
+              }
             ]} = PeopleEctoMultipleIndexes.reindex()
 
     assert_request("POST", ~r/algoliax_people_en/, %{
@@ -302,18 +308,22 @@ defmodule AlgoliaxTest.Schema do
   test "reindex multiple indexes with force delete" do
     assert {:ok,
             [
-              [
-                {:ok, %Algoliax.Response{}},
-                {:ok, %Algoliax.Response{}}
-              ],
-              [
-                {:ok, %Algoliax.Response{}},
-                {:ok, %Algoliax.Response{}}
-              ],
-              [
-                {:ok, %Algoliax.Response{}},
-                {:ok, %Algoliax.Response{}}
-              ]
+              %Algoliax.Responses{
+                index_name: :algoliax_people_en,
+                responses: [
+                  {:ok, %Algoliax.Response{}},
+                  {:ok, %Algoliax.Response{}},
+                  {:ok, %Algoliax.Response{}}
+                ]
+              },
+              %Algoliax.Responses{
+                index_name: :algoliax_people_fr,
+                responses: [
+                  {:ok, %Algoliax.Response{}},
+                  {:ok, %Algoliax.Response{}},
+                  {:ok, %Algoliax.Response{}}
+                ]
+              }
             ]} = PeopleEctoMultipleIndexes.reindex(force_delete: true)
 
     assert_request("POST", ~r/algoliax_people_en/, %{
@@ -374,8 +384,21 @@ defmodule AlgoliaxTest.Schema do
         where: p.age == 35
       )
 
-    assert {:ok, [[{:ok, %Algoliax.Response{}}, {:ok, %Algoliax.Response{}}]]} =
-             PeopleEctoMultipleIndexes.reindex(query)
+    assert {:ok,
+            [
+              %Algoliax.Responses{
+                index_name: :algoliax_people_en,
+                responses: [
+                  {:ok, %Algoliax.Response{}}
+                ]
+              },
+              %Algoliax.Responses{
+                index_name: :algoliax_people_fr,
+                responses: [
+                  {:ok, %Algoliax.Response{}}
+                ]
+              }
+            ]} = PeopleEctoMultipleIndexes.reindex(query)
 
     assert_request("POST", ~r/algoliax_people_en/, %{
       "requests" => [
@@ -423,14 +446,20 @@ defmodule AlgoliaxTest.Schema do
 
     assert {:ok,
             [
-              [
-                {:ok, %Algoliax.Response{}},
-                {:ok, %Algoliax.Response{}}
-              ],
-              [
-                {:ok, %Algoliax.Response{}},
-                {:ok, %Algoliax.Response{}}
-              ]
+              %Algoliax.Responses{
+                index_name: :algoliax_people_en,
+                responses: [
+                  {:ok, %Algoliax.Response{}},
+                  {:ok, %Algoliax.Response{}}
+                ]
+              },
+              %Algoliax.Responses{
+                index_name: :algoliax_people_fr,
+                responses: [
+                  {:ok, %Algoliax.Response{}},
+                  {:ok, %Algoliax.Response{}}
+                ]
+              }
             ]} = PeopleEctoMultipleIndexes.reindex(query, force_delete: true)
 
     assert_request("POST", ~r/algoliax_people_en/, %{
@@ -479,7 +508,7 @@ defmodule AlgoliaxTest.Schema do
     })
   end
 
-  test "reindex multiple indeixes atomic" do
+  test "reindex atomic for multiple indexes" do
     assert [{:ok, :completed}, {:ok, :completed}] = PeopleEctoMultipleIndexes.reindex_atomic()
 
     assert_request("POST", ~r/algoliax_people_en/, %{
@@ -566,18 +595,22 @@ defmodule AlgoliaxTest.Schema do
   test "reindex multiple indexes without an id column" do
     assert {:ok,
             [
-              [
-                {:ok, %Algoliax.Response{}},
-                {:ok, %Algoliax.Response{}}
-              ],
-              [
-                {:ok, %Algoliax.Response{}},
-                {:ok, %Algoliax.Response{}}
-              ],
-              [
-                {:ok, %Algoliax.Response{}},
-                {:ok, %Algoliax.Response{}}
-              ]
+              %Algoliax.Responses{
+                index_name: :algoliax_people_without_id_en,
+                responses: [
+                  {:ok, %Algoliax.Response{}},
+                  {:ok, %Algoliax.Response{}},
+                  {:ok, %Algoliax.Response{}}
+                ]
+              },
+              %Algoliax.Responses{
+                index_name: :algoliax_people_without_id_fr,
+                responses: [
+                  {:ok, %Algoliax.Response{}},
+                  {:ok, %Algoliax.Response{}},
+                  {:ok, %Algoliax.Response{}}
+                ]
+              }
             ]} = PeopleWithoutIdEctoMultipleIndexes.reindex()
 
     assert_request("POST", ~r/algoliax_people_without_id_en/, %{
@@ -627,7 +660,7 @@ defmodule AlgoliaxTest.Schema do
   end
 
   test "save_object/1 without attribute(s) and multiple indexes" do
-    assert [{:ok, _}, {:ok, _}] =
+    assert {:ok, [%Algoliax.Responses{}, %Algoliax.Responses{}]} =
              PeopleWithSchemasMultipleIndexes.save_object(%Beer{
                kind: "brune",
                name: "chimay",
@@ -710,7 +743,21 @@ defmodule AlgoliaxTest.Schema do
         where: b.name == "chimay"
       )
 
-    assert {:ok, [[{:ok, _}, {:ok, _}]]} = PeopleWithSchemasMultipleIndexes.reindex(query)
+    assert {:ok,
+            [
+              %Algoliax.Responses{
+                index_name: :algoliax_with_schemas_en,
+                responses: [
+                  {:ok, %Algoliax.Response{}}
+                ]
+              },
+              %Algoliax.Responses{
+                index_name: :algoliax_with_schemas_fr,
+                responses: [
+                  {:ok, %Algoliax.Response{}}
+                ]
+              }
+            ]} = PeopleWithSchemasMultipleIndexes.reindex(query)
 
     assert_request("POST", ~r/algoliax_with_schemas_en/, %{
       "requests" => [
@@ -738,7 +785,22 @@ defmodule AlgoliaxTest.Schema do
 
   test "reindex/1 with schemas, query as keyword list and multiple indexes" do
     query = %{where: [name: "heineken"]}
-    assert {:ok, [[{:ok, _}, {:ok, _}]]} = PeopleWithSchemasMultipleIndexes.reindex(query)
+
+    assert {:ok,
+            [
+              %Algoliax.Responses{
+                index_name: :algoliax_with_schemas_en,
+                responses: [
+                  {:ok, %Algoliax.Response{}}
+                ]
+              },
+              %Algoliax.Responses{
+                index_name: :algoliax_with_schemas_fr,
+                responses: [
+                  {:ok, %Algoliax.Response{}}
+                ]
+              }
+            ]} = PeopleWithSchemasMultipleIndexes.reindex(query)
 
     assert_request("POST", ~r/algoliax_with_schemas_en/, %{
       "requests" => [
@@ -798,9 +860,22 @@ defmodule AlgoliaxTest.Schema do
     test "reindex with multiple indexes" do
       assert {:ok,
               [
-                [{:ok, %Algoliax.Response{}}, {:ok, %Algoliax.Response{}}],
-                [{:ok, %Algoliax.Response{}}, {:ok, %Algoliax.Response{}}],
-                [{:ok, %Algoliax.Response{}}, {:ok, %Algoliax.Response{}}]
+                %Algoliax.Responses{
+                  index_name: :algoliax_people_with_custom_object_id_en,
+                  responses: [
+                    {:ok, %Algoliax.Response{}},
+                    {:ok, %Algoliax.Response{}},
+                    {:ok, %Algoliax.Response{}}
+                  ]
+                },
+                %Algoliax.Responses{
+                  index_name: :algoliax_people_with_custom_object_id_fr,
+                  responses: [
+                    {:ok, %Algoliax.Response{}},
+                    {:ok, %Algoliax.Response{}},
+                    {:ok, %Algoliax.Response{}}
+                  ]
+                }
               ]} = PeopleWithCustomObjectIdMultipleIndexes.reindex()
 
       assert_request("POST", ~r/algoliax_people_with_custom_object_id_en/, %{

--- a/test/algoliax/struct_test.exs
+++ b/test/algoliax/struct_test.exs
@@ -1,7 +1,11 @@
 defmodule AlgoliaxTest.StructTest do
   use Algoliax.RequestCase
 
-  alias Algoliax.Schemas.{PeopleStruct, PeopleStructRuntimeIndexName}
+  alias Algoliax.Schemas.{
+    PeopleStruct,
+    PeopleStructRuntimeIndexName,
+    PeopleStructWithAdditionalIndexes
+  }
 
   setup do
     Algoliax.SettingsStore.set_settings(:algoliax_people_struct, %{})

--- a/test/algoliax/struct_test.exs
+++ b/test/algoliax/struct_test.exs
@@ -97,7 +97,7 @@ defmodule AlgoliaxTest.StructTest do
 
     test "get_object/1 w/ unknown" do
       person = %PeopleStruct{reference: "unknown", last_name: "Doe", first_name: "John", age: 77}
-      assert {:error, 404, _} = PeopleStruct.get_object(person)
+      assert {:error, 404, _, _} = PeopleStruct.get_object(person)
     end
 
     test "delete_object/1" do
@@ -143,16 +143,28 @@ defmodule AlgoliaxTest.StructTest do
 
   describe "struct with multiple indexes" do
     test "configure_index/0" do
-      assert [{:ok, res}, {:ok, res2}] = PeopleStructMultipleIndexes.configure_index()
+      assert {:ok, [res, res2]} = PeopleStructMultipleIndexes.configure_index()
 
-      assert %Algoliax.Response{
-               response: %{"taskID" => _, "updatedAt" => _},
-               params: [index_name: :algoliax_people_struct_en]
+      assert %Algoliax.Responses{
+               index_name: :algoliax_people_struct_en,
+               responses: [
+                 {:ok,
+                  %Algoliax.Response{
+                    response: %{"taskID" => _, "updatedAt" => _},
+                    params: [index_name: :algoliax_people_struct_en]
+                  }}
+               ]
              } = res
 
-      assert %Algoliax.Response{
-               response: %{"taskID" => _, "updatedAt" => _},
-               params: [index_name: :algoliax_people_struct_fr]
+      assert %Algoliax.Responses{
+               index_name: :algoliax_people_struct_fr,
+               responses: [
+                 {:ok,
+                  %Algoliax.Response{
+                    response: %{"taskID" => _, "updatedAt" => _},
+                    params: [index_name: :algoliax_people_struct_fr]
+                  }}
+               ]
              } = res2
 
       assert_request("PUT", ~r/algoliax_people_struct_en/, %{
@@ -176,16 +188,28 @@ defmodule AlgoliaxTest.StructTest do
         age: 77
       }
 
-      assert [{:ok, res}, {:ok, res2}] = PeopleStructMultipleIndexes.save_object(person)
+      assert {:ok, [res, res2]} = PeopleStructMultipleIndexes.save_object(person)
 
-      assert %Algoliax.Response{
-               response: %{"objectID" => ^reference, "taskID" => _, "updatedAt" => _},
-               params: [index_name: :algoliax_people_struct_en, object_id: ^reference]
+      assert %Algoliax.Responses{
+               index_name: :algoliax_people_struct_en,
+               responses: [
+                 {:ok,
+                  %Algoliax.Response{
+                    response: %{"objectID" => ^reference, "taskID" => _, "updatedAt" => _},
+                    params: [index_name: :algoliax_people_struct_en, object_id: ^reference]
+                  }}
+               ]
              } = res
 
-      assert %Algoliax.Response{
-               response: %{"objectID" => ^reference, "taskID" => _, "updatedAt" => _},
-               params: [index_name: :algoliax_people_struct_fr, object_id: ^reference]
+      assert %Algoliax.Responses{
+               index_name: :algoliax_people_struct_fr,
+               responses: [
+                 {:ok,
+                  %Algoliax.Response{
+                    response: %{"objectID" => ^reference, "taskID" => _, "updatedAt" => _},
+                    params: [index_name: :algoliax_people_struct_fr, object_id: ^reference]
+                  }}
+               ]
              } = res2
 
       assert_request("PUT", ~r/algoliax_people_struct_en/, %{
@@ -228,16 +252,28 @@ defmodule AlgoliaxTest.StructTest do
         }
       ]
 
-      assert [{:ok, res}, {:ok, res2}] = PeopleStructMultipleIndexes.save_objects(people)
+      assert {:ok, [res, res2]} = PeopleStructMultipleIndexes.save_objects(people)
 
-      assert %Algoliax.Response{
-               response: %{"taskID" => _, "objectIDs" => [^reference1]},
-               params: [index_name: :algoliax_people_struct_en]
+      assert %Algoliax.Responses{
+               index_name: :algoliax_people_struct_en,
+               responses: [
+                 {:ok,
+                  %Algoliax.Response{
+                    response: %{"taskID" => _, "objectIDs" => [^reference1]},
+                    params: [index_name: :algoliax_people_struct_en]
+                  }}
+               ]
              } = res
 
-      assert %Algoliax.Response{
-               response: %{"taskID" => _, "objectIDs" => [^reference1]},
-               params: [index_name: :algoliax_people_struct_fr]
+      assert %Algoliax.Responses{
+               index_name: :algoliax_people_struct_fr,
+               responses: [
+                 {:ok,
+                  %Algoliax.Response{
+                    response: %{"taskID" => _, "objectIDs" => [^reference1]},
+                    params: [index_name: :algoliax_people_struct_fr]
+                  }}
+               ]
              } = res2
 
       assert_request("POST", ~r/algoliax_people_struct_en/, %{
@@ -268,17 +304,29 @@ defmodule AlgoliaxTest.StructTest do
         }
       ]
 
-      assert [{:ok, res}, {:ok, res2}] =
+      assert {:ok, [res, res2]} =
                PeopleStructMultipleIndexes.save_objects(people, force_delete: true)
 
-      assert %Algoliax.Response{
-               response: %{"taskID" => _, "objectIDs" => [^reference1, ^reference2]},
-               params: [index_name: :algoliax_people_struct_en]
+      assert %Algoliax.Responses{
+               index_name: :algoliax_people_struct_en,
+               responses: [
+                 {:ok,
+                  %Algoliax.Response{
+                    response: %{"taskID" => _, "objectIDs" => [^reference1, ^reference2]},
+                    params: [index_name: :algoliax_people_struct_en]
+                  }}
+               ]
              } = res
 
-      assert %Algoliax.Response{
-               response: %{"taskID" => _, "objectIDs" => [^reference1, ^reference2]},
-               params: [index_name: :algoliax_people_struct_fr]
+      assert %Algoliax.Responses{
+               index_name: :algoliax_people_struct_fr,
+               responses: [
+                 {:ok,
+                  %Algoliax.Response{
+                    response: %{"taskID" => _, "objectIDs" => [^reference1, ^reference2]},
+                    params: [index_name: :algoliax_people_struct_fr]
+                  }}
+               ]
              } = res2
 
       assert_request("POST", ~r/algoliax_people_struct_en/, %{
@@ -304,16 +352,28 @@ defmodule AlgoliaxTest.StructTest do
         age: 77
       }
 
-      assert [{:ok, res}, {:ok, res2}] = PeopleStructMultipleIndexes.get_object(person)
+      assert {:ok, [res, res2]} = PeopleStructMultipleIndexes.get_object(person)
 
-      assert %Algoliax.Response{
-               response: %{"objectID" => "known"},
-               params: [index_name: :algoliax_people_struct_en, object_id: "known"]
+      assert %Algoliax.Responses{
+               index_name: :algoliax_people_struct_en,
+               responses: [
+                 {:ok,
+                  %Algoliax.Response{
+                    response: %{"objectID" => "known"},
+                    params: [index_name: :algoliax_people_struct_en, object_id: "known"]
+                  }}
+               ]
              } = res
 
-      assert %Algoliax.Response{
-               response: %{"objectID" => "known"},
-               params: [index_name: :algoliax_people_struct_fr, object_id: "known"]
+      assert %Algoliax.Responses{
+               index_name: :algoliax_people_struct_fr,
+               responses: [
+                 {:ok,
+                  %Algoliax.Response{
+                    response: %{"objectID" => "known"},
+                    params: [index_name: :algoliax_people_struct_fr, object_id: "known"]
+                  }}
+               ]
              } = res2
 
       assert_request("GET", ~r/algoliax_people_struct_en/, %{})
@@ -328,7 +388,17 @@ defmodule AlgoliaxTest.StructTest do
         age: 77
       }
 
-      assert [{:error, 404, _}, {:error, 404, _}] = PeopleStructMultipleIndexes.get_object(person)
+      assert {:ok,
+              [
+                %Algoliax.Responses{
+                  index_name: :algoliax_people_struct_en,
+                  responses: [{:error, 404, "{}", _}]
+                },
+                %Algoliax.Responses{
+                  index_name: :algoliax_people_struct_fr,
+                  responses: [{:error, 404, "{}", _}]
+                }
+              ]} = PeopleStructMultipleIndexes.get_object(person)
     end
 
     test "delete_object/1" do
@@ -339,7 +409,12 @@ defmodule AlgoliaxTest.StructTest do
         age: 77
       }
 
-      assert [{:ok, _}, {:ok, _}] = PeopleStructMultipleIndexes.delete_object(person)
+      assert {:ok,
+              [
+                %Algoliax.Responses{index_name: :algoliax_people_struct_en},
+                %Algoliax.Responses{index_name: :algoliax_people_struct_fr}
+              ]} = PeopleStructMultipleIndexes.delete_object(person)
+
       assert_request("DELETE", ~r/algoliax_people_struct_en/, %{})
       assert_request("DELETE", ~r/algoliax_people_struct_fr/, %{})
     end
@@ -349,22 +424,39 @@ defmodule AlgoliaxTest.StructTest do
     end
 
     test "delete_index/0" do
-      assert [{:ok, _}, {:ok, _}] = PeopleStructMultipleIndexes.delete_index()
+      assert {:ok,
+              [
+                %Algoliax.Responses{index_name: :algoliax_people_struct_en},
+                %Algoliax.Responses{index_name: :algoliax_people_struct_fr}
+              ]} = PeopleStructMultipleIndexes.delete_index()
+
       assert_request("DELETE", ~r/algoliax_people_struct_en/, %{})
       assert_request("DELETE", ~r/algoliax_people_struct_fr/, %{})
     end
 
     test "get_settings/0" do
-      assert [{:ok, res}, {:ok, res2}] = PeopleStructMultipleIndexes.get_settings()
+      assert {:ok, [res, res2]} = PeopleStructMultipleIndexes.get_settings()
 
-      assert %Algoliax.Response{
-               response: %{"searchableAttributes" => ["test"]},
-               params: [index_name: :algoliax_people_struct_en]
+      assert %Algoliax.Responses{
+               index_name: :algoliax_people_struct_en,
+               responses: [
+                 {:ok,
+                  %Algoliax.Response{
+                    response: %{"searchableAttributes" => ["test"]},
+                    params: [index_name: :algoliax_people_struct_en]
+                  }}
+               ]
              } = res
 
-      assert %Algoliax.Response{
-               response: %{"searchableAttributes" => ["test"]},
-               params: [index_name: :algoliax_people_struct_fr]
+      assert %Algoliax.Responses{
+               index_name: :algoliax_people_struct_fr,
+               responses: [
+                 {:ok,
+                  %Algoliax.Response{
+                    response: %{"searchableAttributes" => ["test"]},
+                    params: [index_name: :algoliax_people_struct_fr]
+                  }}
+               ]
              } = res2
 
       assert_request("GET", ~r/algoliax_people_struct_en/, %{})
@@ -372,7 +464,11 @@ defmodule AlgoliaxTest.StructTest do
     end
 
     test "search/2" do
-      assert [{:ok, _}, {:ok, _}] = PeopleStructMultipleIndexes.search("john", %{hitsPerPage: 10})
+      assert assert {:ok,
+                     [
+                       %Algoliax.Responses{index_name: :algoliax_people_struct_en},
+                       %Algoliax.Responses{index_name: :algoliax_people_struct_fr}
+                     ]} = PeopleStructMultipleIndexes.search("john", %{hitsPerPage: 10})
 
       assert_request("POST", ~r/algoliax_people_struct_en/, %{
         "query" => "john",
@@ -386,22 +482,39 @@ defmodule AlgoliaxTest.StructTest do
     end
 
     test "search_facet/2" do
-      assert [{:ok, _}, {:ok, _}] = PeopleStructMultipleIndexes.search_facet("age", "2")
+      assert {:ok,
+              [
+                %Algoliax.Responses{index_name: :algoliax_people_struct_en},
+                %Algoliax.Responses{index_name: :algoliax_people_struct_fr}
+              ]} = PeopleStructMultipleIndexes.search_facet("age", "2")
+
       assert_request("POST", ~r/algoliax_people_struct_en/, %{"facetQuery" => "2"})
       assert_request("POST", ~r/algoliax_people_struct_fr/, %{"facetQuery" => "2"})
     end
 
     test "delete_by/1" do
-      assert [{:ok, res}, {:ok, res2}] = PeopleStructMultipleIndexes.delete_by("age > 18")
+      assert {:ok, [res, res2]} = PeopleStructMultipleIndexes.delete_by("age > 18")
 
-      assert %Algoliax.Response{
-               response: %{"taskID" => _, "updatedAt" => _},
-               params: [index_name: :algoliax_people_struct_en]
+      assert %Algoliax.Responses{
+               index_name: :algoliax_people_struct_en,
+               responses: [
+                 {:ok,
+                  %Algoliax.Response{
+                    response: %{"taskID" => _, "updatedAt" => _},
+                    params: [index_name: :algoliax_people_struct_en]
+                  }}
+               ]
              } = res
 
-      assert %Algoliax.Response{
-               response: %{"taskID" => _, "updatedAt" => _},
-               params: [index_name: :algoliax_people_struct_fr]
+      assert %Algoliax.Responses{
+               index_name: :algoliax_people_struct_fr,
+               responses: [
+                 {:ok,
+                  %Algoliax.Response{
+                    response: %{"taskID" => _, "updatedAt" => _},
+                    params: [index_name: :algoliax_people_struct_fr]
+                  }}
+               ]
              } = res2
 
       assert_request("POST", ~r/algoliax_people_struct_en/, %{"params" => "filters=age > 18"})
@@ -435,16 +548,28 @@ defmodule AlgoliaxTest.StructTest do
         age: 77
       }
 
-      assert [{:ok, res}, {:ok, res2}] = PeopleStructRuntimeMultipleIndexes.get_object(person)
+      assert {:ok, [res, res2]} = PeopleStructRuntimeMultipleIndexes.get_object(person)
 
-      assert %Algoliax.Response{
-               response: %{"objectID" => "known"},
-               params: [index_name: :people_runtime_index_name_en, object_id: "known"]
+      assert %Algoliax.Responses{
+               index_name: :people_runtime_index_name_en,
+               responses: [
+                 {:ok,
+                  %Algoliax.Response{
+                    response: %{"objectID" => "known"},
+                    params: [index_name: :people_runtime_index_name_en, object_id: "known"]
+                  }}
+               ]
              } = res
 
-      assert %Algoliax.Response{
-               response: %{"objectID" => "known"},
-               params: [index_name: :people_runtime_index_name_fr, object_id: "known"]
+      assert %Algoliax.Responses{
+               index_name: :people_runtime_index_name_fr,
+               responses: [
+                 {:ok,
+                  %Algoliax.Response{
+                    response: %{"objectID" => "known"},
+                    params: [index_name: :people_runtime_index_name_fr, object_id: "known"]
+                  }}
+               ]
              } = res2
 
       assert_request("PUT", ~r/people_runtime_index_name_en\/settings/, %{})

--- a/test/algoliax/struct_test.exs
+++ b/test/algoliax/struct_test.exs
@@ -3,8 +3,9 @@ defmodule AlgoliaxTest.StructTest do
 
   alias Algoliax.Schemas.{
     PeopleStruct,
-    PeopleStructRuntimeIndexName,
-    PeopleStructWithAdditionalIndexes
+    PeopleStructMultipleIndexes,
+    PeopleStructRuntimeMultipleIndexes,
+    PeopleStructRuntimeIndexName
   }
 
   setup do
@@ -25,7 +26,7 @@ defmodule AlgoliaxTest.StructTest do
     end
 
     test "save_object/1" do
-      reference = :random.uniform(1_000_000) |> to_string()
+      reference = :rand.uniform(1_000_000) |> to_string()
       person = %PeopleStruct{reference: reference, last_name: "Doe", first_name: "John", age: 77}
       assert {:ok, res} = PeopleStruct.save_object(person)
 
@@ -45,8 +46,8 @@ defmodule AlgoliaxTest.StructTest do
     end
 
     test "save_objects/1" do
-      reference1 = :random.uniform(1_000_000) |> to_string()
-      reference2 = :random.uniform(1_000_000) |> to_string()
+      reference1 = :rand.uniform(1_000_000) |> to_string()
+      reference2 = :rand.uniform(1_000_000) |> to_string()
 
       people = [
         %PeopleStruct{reference: reference1, last_name: "Doe", first_name: "John", age: 77},
@@ -65,8 +66,8 @@ defmodule AlgoliaxTest.StructTest do
     end
 
     test "save_objects/1 w/ force_delete: true" do
-      reference1 = :random.uniform(1_000_000) |> to_string()
-      reference2 = :random.uniform(1_000_000) |> to_string()
+      reference1 = :rand.uniform(1_000_000) |> to_string()
+      reference2 = :rand.uniform(1_000_000) |> to_string()
 
       people = [
         %PeopleStruct{reference: reference1, last_name: "Doe", first_name: "John", age: 77},
@@ -140,6 +141,274 @@ defmodule AlgoliaxTest.StructTest do
     end
   end
 
+  describe "struct with multiple indexes" do
+    test "configure_index/0" do
+      assert [{:ok, res}, {:ok, res2}] = PeopleStructMultipleIndexes.configure_index()
+
+      assert %Algoliax.Response{
+               response: %{"taskID" => _, "updatedAt" => _},
+               params: [index_name: :algoliax_people_struct_en]
+             } = res
+
+      assert %Algoliax.Response{
+               response: %{"taskID" => _, "updatedAt" => _},
+               params: [index_name: :algoliax_people_struct_fr]
+             } = res2
+
+      assert_request("PUT", ~r/algoliax_people_struct_en/, %{
+        "searchableAttributes" => ["full_name"],
+        "attributesForFaceting" => ["age"]
+      })
+
+      assert_request("PUT", ~r/algoliax_people_struct_fr/, %{
+        "searchableAttributes" => ["full_name"],
+        "attributesForFaceting" => ["age"]
+      })
+    end
+
+    test "save_object/1" do
+      reference = :rand.uniform(1_000_000) |> to_string()
+
+      person = %PeopleStructMultipleIndexes{
+        reference: reference,
+        last_name: "Doe",
+        first_name: "John",
+        age: 77
+      }
+
+      assert [{:ok, res}, {:ok, res2}] = PeopleStructMultipleIndexes.save_object(person)
+
+      assert %Algoliax.Response{
+               response: %{"objectID" => ^reference, "taskID" => _, "updatedAt" => _},
+               params: [index_name: :algoliax_people_struct_en, object_id: ^reference]
+             } = res
+
+      assert %Algoliax.Response{
+               response: %{"objectID" => ^reference, "taskID" => _, "updatedAt" => _},
+               params: [index_name: :algoliax_people_struct_fr, object_id: ^reference]
+             } = res2
+
+      assert_request("PUT", ~r/algoliax_people_struct_en/, %{
+        "age" => 77,
+        "first_name" => "John",
+        "full_name" => "John Doe",
+        "last_name" => "Doe",
+        "nickname" => "john",
+        "objectID" => reference,
+        "updated_at" => 1_546_300_800
+      })
+
+      assert_request("PUT", ~r/algoliax_people_struct_fr/, %{
+        "age" => 77,
+        "first_name" => "John",
+        "full_name" => "John Doe",
+        "last_name" => "Doe",
+        "nickname" => "john",
+        "objectID" => reference,
+        "updated_at" => 1_546_300_800
+      })
+    end
+
+    test "save_objects/1" do
+      reference1 = :rand.uniform(1_000_000) |> to_string()
+      reference2 = :rand.uniform(1_000_000) |> to_string()
+
+      people = [
+        %PeopleStructMultipleIndexes{
+          reference: reference1,
+          last_name: "Doe",
+          first_name: "John",
+          age: 77
+        },
+        %PeopleStructMultipleIndexes{
+          reference: reference2,
+          last_name: "al",
+          first_name: "bert",
+          age: 35
+        }
+      ]
+
+      assert [{:ok, res}, {:ok, res2}] = PeopleStructMultipleIndexes.save_objects(people)
+
+      assert %Algoliax.Response{
+               response: %{"taskID" => _, "objectIDs" => [^reference1]},
+               params: [index_name: :algoliax_people_struct_en]
+             } = res
+
+      assert %Algoliax.Response{
+               response: %{"taskID" => _, "objectIDs" => [^reference1]},
+               params: [index_name: :algoliax_people_struct_fr]
+             } = res2
+
+      assert_request("POST", ~r/algoliax_people_struct_en/, %{
+        "requests" => [%{"action" => "updateObject", "body" => %{"objectID" => reference1}}]
+      })
+
+      assert_request("POST", ~r/algoliax_people_struct_fr/, %{
+        "requests" => [%{"action" => "updateObject", "body" => %{"objectID" => reference1}}]
+      })
+    end
+
+    test "save_objects/1 w/ force_delete: true" do
+      reference1 = :rand.uniform(1_000_000) |> to_string()
+      reference2 = :rand.uniform(1_000_000) |> to_string()
+
+      people = [
+        %PeopleStructMultipleIndexes{
+          reference: reference1,
+          last_name: "Doe",
+          first_name: "John",
+          age: 77
+        },
+        %PeopleStructMultipleIndexes{
+          reference: reference2,
+          last_name: "al",
+          first_name: "bert",
+          age: 35
+        }
+      ]
+
+      assert [{:ok, res}, {:ok, res2}] =
+               PeopleStructMultipleIndexes.save_objects(people, force_delete: true)
+
+      assert %Algoliax.Response{
+               response: %{"taskID" => _, "objectIDs" => [^reference1, ^reference2]},
+               params: [index_name: :algoliax_people_struct_en]
+             } = res
+
+      assert %Algoliax.Response{
+               response: %{"taskID" => _, "objectIDs" => [^reference1, ^reference2]},
+               params: [index_name: :algoliax_people_struct_fr]
+             } = res2
+
+      assert_request("POST", ~r/algoliax_people_struct_en/, %{
+        "requests" => [
+          %{"action" => "updateObject", "body" => %{"objectID" => reference1}},
+          %{"action" => "deleteObject", "body" => %{"objectID" => reference2}}
+        ]
+      })
+
+      assert_request("POST", ~r/algoliax_people_struct_fr/, %{
+        "requests" => [
+          %{"action" => "updateObject", "body" => %{"objectID" => reference1}},
+          %{"action" => "deleteObject", "body" => %{"objectID" => reference2}}
+        ]
+      })
+    end
+
+    test "get_object/1" do
+      person = %PeopleStructMultipleIndexes{
+        reference: "known",
+        last_name: "Doe",
+        first_name: "John",
+        age: 77
+      }
+
+      assert [{:ok, res}, {:ok, res2}] = PeopleStructMultipleIndexes.get_object(person)
+
+      assert %Algoliax.Response{
+               response: %{"objectID" => "known"},
+               params: [index_name: :algoliax_people_struct_en, object_id: "known"]
+             } = res
+
+      assert %Algoliax.Response{
+               response: %{"objectID" => "known"},
+               params: [index_name: :algoliax_people_struct_fr, object_id: "known"]
+             } = res2
+
+      assert_request("GET", ~r/algoliax_people_struct_en/, %{})
+      assert_request("GET", ~r/algoliax_people_struct_fr/, %{})
+    end
+
+    test "get_object/1 w/ unknown" do
+      person = %PeopleStructMultipleIndexes{
+        reference: "unknown",
+        last_name: "Doe",
+        first_name: "John",
+        age: 77
+      }
+
+      assert [{:error, 404, _}, {:error, 404, _}] = PeopleStructMultipleIndexes.get_object(person)
+    end
+
+    test "delete_object/1" do
+      person = %PeopleStructMultipleIndexes{
+        reference: "unknown",
+        last_name: "Doe",
+        first_name: "John",
+        age: 77
+      }
+
+      assert [{:ok, _}, {:ok, _}] = PeopleStructMultipleIndexes.delete_object(person)
+      assert_request("DELETE", ~r/algoliax_people_struct_en/, %{})
+      assert_request("DELETE", ~r/algoliax_people_struct_fr/, %{})
+    end
+
+    test "reindex/0" do
+      assert_raise(Algoliax.MissingRepoError, fn -> PeopleStructMultipleIndexes.reindex() end)
+    end
+
+    test "delete_index/0" do
+      assert [{:ok, _}, {:ok, _}] = PeopleStructMultipleIndexes.delete_index()
+      assert_request("DELETE", ~r/algoliax_people_struct_en/, %{})
+      assert_request("DELETE", ~r/algoliax_people_struct_fr/, %{})
+    end
+
+    test "get_settings/0" do
+      assert [{:ok, res}, {:ok, res2}] = PeopleStructMultipleIndexes.get_settings()
+
+      assert %Algoliax.Response{
+               response: %{"searchableAttributes" => ["test"]},
+               params: [index_name: :algoliax_people_struct_en]
+             } = res
+
+      assert %Algoliax.Response{
+               response: %{"searchableAttributes" => ["test"]},
+               params: [index_name: :algoliax_people_struct_fr]
+             } = res2
+
+      assert_request("GET", ~r/algoliax_people_struct_en/, %{})
+      assert_request("GET", ~r/algoliax_people_struct_fr/, %{})
+    end
+
+    test "search/2" do
+      assert [{:ok, _}, {:ok, _}] = PeopleStructMultipleIndexes.search("john", %{hitsPerPage: 10})
+
+      assert_request("POST", ~r/algoliax_people_struct_en/, %{
+        "query" => "john",
+        "hitsPerPage" => 10
+      })
+
+      assert_request("POST", ~r/algoliax_people_struct_fr/, %{
+        "query" => "john",
+        "hitsPerPage" => 10
+      })
+    end
+
+    test "search_facet/2" do
+      assert [{:ok, _}, {:ok, _}] = PeopleStructMultipleIndexes.search_facet("age", "2")
+      assert_request("POST", ~r/algoliax_people_struct_en/, %{"facetQuery" => "2"})
+      assert_request("POST", ~r/algoliax_people_struct_fr/, %{"facetQuery" => "2"})
+    end
+
+    test "delete_by/1" do
+      assert [{:ok, res}, {:ok, res2}] = PeopleStructMultipleIndexes.delete_by("age > 18")
+
+      assert %Algoliax.Response{
+               response: %{"taskID" => _, "updatedAt" => _},
+               params: [index_name: :algoliax_people_struct_en]
+             } = res
+
+      assert %Algoliax.Response{
+               response: %{"taskID" => _, "updatedAt" => _},
+               params: [index_name: :algoliax_people_struct_fr]
+             } = res2
+
+      assert_request("POST", ~r/algoliax_people_struct_en/, %{"params" => "filters=age > 18"})
+      assert_request("POST", ~r/algoliax_people_struct_fr/, %{"params" => "filters=age > 18"})
+    end
+  end
+
   describe "runtime index name" do
     test "get_object/1" do
       person = %PeopleStructRuntimeIndexName{
@@ -157,8 +426,39 @@ defmodule AlgoliaxTest.StructTest do
     end
   end
 
+  describe "runtime multiple indexes" do
+    test "get_object/1" do
+      person = %PeopleStructRuntimeMultipleIndexes{
+        reference: "known",
+        last_name: "Doe",
+        first_name: "John",
+        age: 77
+      }
+
+      assert [{:ok, res}, {:ok, res2}] = PeopleStructRuntimeMultipleIndexes.get_object(person)
+
+      assert %Algoliax.Response{
+               response: %{"objectID" => "known"},
+               params: [index_name: :people_runtime_index_name_en, object_id: "known"]
+             } = res
+
+      assert %Algoliax.Response{
+               response: %{"objectID" => "known"},
+               params: [index_name: :people_runtime_index_name_fr, object_id: "known"]
+             } = res2
+
+      assert_request("PUT", ~r/people_runtime_index_name_en\/settings/, %{})
+      assert_request("GET", ~r/people_runtime_index_name_en\/settings/, %{})
+      assert_request("GET", ~r/people_runtime_index_name_en\/known/, %{})
+
+      assert_request("PUT", ~r/people_runtime_index_name_fr\/settings/, %{})
+      assert_request("GET", ~r/people_runtime_index_name_fr\/settings/, %{})
+      assert_request("GET", ~r/people_runtime_index_name_fr\/known/, %{})
+    end
+  end
+
   describe "wait for task" do
-    reference = :random.uniform(1_000_000) |> to_string()
+    reference = :rand.uniform(1_000_000) |> to_string()
     person = %PeopleStruct{reference: reference, last_name: "Doe", first_name: "John", age: 77}
     assert {:ok, res} = PeopleStruct.save_object(person) |> Algoliax.wait_task()
 
@@ -171,5 +471,40 @@ defmodule AlgoliaxTest.StructTest do
     assert_request("GET", ~r/algoliax_people_struct\/task\/#{task_id}/, %{})
     assert_request("GET", ~r/algoliax_people_struct\/task\/#{task_id}/, %{})
     assert_request("GET", ~r/algoliax_people_struct\/task\/#{task_id}/, %{})
+  end
+
+  describe "wait for task with multiple indexes" do
+    reference = :rand.uniform(1_000_000) |> to_string()
+
+    person = %PeopleStructMultipleIndexes{
+      reference: reference,
+      last_name: "Doe",
+      first_name: "John",
+      age: 77
+    }
+
+    assert [{:ok, res}, {:ok, res2}] =
+             PeopleStructMultipleIndexes.save_object(person) |> Algoliax.wait_task()
+
+    assert %Algoliax.Response{
+             response: %{"objectID" => ^reference, "taskID" => task_id, "updatedAt" => _},
+             params: [index_name: :algoliax_people_struct_en, object_id: ^reference]
+           } = res
+
+    assert %Algoliax.Response{
+             response: %{"objectID" => ^reference, "taskID" => task_id2, "updatedAt" => _},
+             params: [index_name: :algoliax_people_struct_fr, object_id: ^reference]
+           } = res2
+
+    # Assert that there are 4 calls to check task status per index
+    assert_request("GET", ~r/algoliax_people_struct_en\/task\/#{task_id}/, %{})
+    assert_request("GET", ~r/algoliax_people_struct_en\/task\/#{task_id}/, %{})
+    assert_request("GET", ~r/algoliax_people_struct_en\/task\/#{task_id}/, %{})
+    assert_request("GET", ~r/algoliax_people_struct_en\/task\/#{task_id}/, %{})
+
+    assert_request("GET", ~r/algoliax_people_struct_fr\/task\/#{task_id2}/, %{})
+    assert_request("GET", ~r/algoliax_people_struct_fr\/task\/#{task_id2}/, %{})
+    assert_request("GET", ~r/algoliax_people_struct_fr\/task\/#{task_id2}/, %{})
+    assert_request("GET", ~r/algoliax_people_struct_fr\/task\/#{task_id2}/, %{})
   end
 end

--- a/test/algoliax/utils_test.exs
+++ b/test/algoliax/utils_test.exs
@@ -21,9 +21,27 @@ defmodule Algoliax.UtilsTest do
     def algoliax_people do
       :algoliax_people_from_function
     end
+  end
 
-    def additional_indexes do
-      [:index_en, :index_fr]
+  defmodule MultipleIndexNames do
+    use Algoliax.Indexer,
+      index_name: [:algoliax_people_en, :algoliax_people_fr],
+      attributes_for_faceting: ["age"],
+      searchable_attributes: ["full_name"],
+      custom_ranking: ["desc(updated_at)"],
+      object_id: :reference
+  end
+
+  defmodule MultipleIndexNameFromFunction do
+    use Algoliax.Indexer,
+      index_name: :algoliax_people,
+      attributes_for_faceting: ["age"],
+      searchable_attributes: ["full_name"],
+      custom_ranking: ["desc(updated_at)"],
+      object_id: :reference
+
+    def algoliax_people do
+      [:algoliax_people_from_function_en, :algoliax_people_from_function_fr]
     end
   end
 
@@ -75,6 +93,18 @@ defmodule Algoliax.UtilsTest do
     test "without a function" do
       assert Algoliax.Utils.index_name(NoRepo, index_name: :algoliax_people) ==
                [:algoliax_people]
+    end
+
+    test "multiple indexes with a function" do
+      assert Algoliax.Utils.index_name(MultipleIndexNameFromFunction, index_name: :algoliax_people) ==
+               [:algoliax_people_from_function_en, :algoliax_people_from_function_fr]
+    end
+
+    test "multiple indexes without a function" do
+      assert Algoliax.Utils.index_name(MultipleIndexNames,
+               index_name: [:algoliax_people_en, :algoliax_people_fr]
+             ) ==
+               [:algoliax_people_en, :algoliax_people_fr]
     end
   end
 end

--- a/test/algoliax/utils_test.exs
+++ b/test/algoliax/utils_test.exs
@@ -21,6 +21,10 @@ defmodule Algoliax.UtilsTest do
     def algoliax_people do
       :algoliax_people_from_function
     end
+
+    def additional_indexes do
+      [:index_en, :index_fr]
+    end
   end
 
   defmodule NoIndexName do
@@ -62,15 +66,15 @@ defmodule Algoliax.UtilsTest do
     end
   end
 
-  describe "should get correct index_name" do
-    test "if there is a function" do
+  describe "index_name/2" do
+    test "with a function" do
       assert Algoliax.Utils.index_name(IndexNameFromFunction, index_name: :algoliax_people) ==
-               :algoliax_people_from_function
+               [:algoliax_people_from_function]
     end
 
-    test "if there is not function" do
+    test "without a function" do
       assert Algoliax.Utils.index_name(NoRepo, index_name: :algoliax_people) ==
-               :algoliax_people
+               [:algoliax_people]
     end
   end
 end

--- a/test/support/schemas/flower.ex
+++ b/test/support/schemas/flower.ex
@@ -1,0 +1,15 @@
+defmodule Algoliax.Schemas.Flower do
+  @moduledoc false
+  use Ecto.Schema
+
+  schema "flowers" do
+    field(:kind)
+
+    belongs_to(
+      :people_with_association_multiple_indexes,
+      Algoliax.Schemas.PeopleWithAssociationMultipleIndexes
+    )
+
+    timestamps()
+  end
+end

--- a/test/support/schemas/people_ecto_fail_multiple_indexes.ex
+++ b/test/support/schemas/people_ecto_fail_multiple_indexes.ex
@@ -1,0 +1,41 @@
+defmodule Algoliax.Schemas.PeopleEctoFailMultipleIndexes do
+  @moduledoc false
+
+  use Ecto.Schema
+
+  use Algoliax.Indexer,
+    index_name: [:algoliax_people_fail_en, :algoliax_people_fail_fr],
+    repo: Algoliax.Repo,
+    object_id: :reference,
+    cursor_field: :id,
+    algolia: [
+      attributes_for_faceting: ["age", "gender"],
+      searchable_attributes: ["full_name", "gender"],
+      custom_ranking: ["desc(updated_at)"]
+    ]
+
+  @primary_key {:reference, Ecto.UUID, autogenerate: true}
+  schema "peoples_fail" do
+    field(:last_name)
+    field(:first_name)
+    field(:age, :integer)
+    field(:gender, :string)
+
+    timestamps()
+  end
+
+  def build_object(people) do
+    %{
+      first_name: people.first_name,
+      last_name: people.last_name,
+      age: people.age,
+      updated_at: ~U[2019-01-01 00:00:00Z] |> DateTime.to_unix(),
+      full_name: Map.get(people, :first_name, "") <> " " <> Map.get(people, :last_name, ""),
+      nickname: Map.get(people, :first_name, "") |> String.downcase()
+    }
+  end
+
+  def to_be_indexed?(people) do
+    people.age > 10
+  end
+end

--- a/test/support/schemas/people_ecto_multiple_indexes.ex
+++ b/test/support/schemas/people_ecto_multiple_indexes.ex
@@ -1,0 +1,40 @@
+defmodule Algoliax.Schemas.PeopleEctoMultipleIndexes do
+  @moduledoc false
+
+  use Ecto.Schema
+
+  use Algoliax.Indexer,
+    index_name: [:algoliax_people_en, :algoliax_people_fr],
+    repo: Algoliax.Repo,
+    object_id: :reference,
+    algolia: [
+      attributes_for_faceting: ["age", "gender"],
+      searchable_attributes: ["full_name", "gender"],
+      custom_ranking: ["desc(updated_at)"]
+    ]
+
+  schema "peoples" do
+    field(:reference, Ecto.UUID)
+    field(:last_name)
+    field(:first_name)
+    field(:age, :integer)
+    field(:gender, :string)
+
+    timestamps()
+  end
+
+  def build_object(people) do
+    %{
+      first_name: people.first_name,
+      last_name: people.last_name,
+      age: people.age,
+      updated_at: ~U[2019-01-01 00:00:00Z] |> DateTime.to_unix(),
+      full_name: Map.get(people, :first_name, "") <> " " <> Map.get(people, :last_name, ""),
+      nickname: Map.get(people, :first_name, "") |> String.downcase()
+    }
+  end
+
+  def to_be_indexed?(people) do
+    people.age > 10
+  end
+end

--- a/test/support/schemas/people_struct_multiple_indexes.ex
+++ b/test/support/schemas/people_struct_multiple_indexes.ex
@@ -1,4 +1,4 @@
-defmodule Algoliax.Schemas.PeopleStructWithAdditionalIndexes do
+defmodule Algoliax.Schemas.PeopleStructMultipleIndexes do
   @moduledoc false
 
   use Algoliax.Indexer,

--- a/test/support/schemas/people_struct_runtime_multiple_indexes.ex
+++ b/test/support/schemas/people_struct_runtime_multiple_indexes.ex
@@ -1,0 +1,18 @@
+defmodule Algoliax.Schemas.PeopleStructRuntimeMultipleIndexes do
+  @moduledoc false
+
+  use Algoliax.Indexer,
+    index_name: :method_to_fetch_index_name,
+    object_id: :reference,
+    algolia: [
+      attributes_for_faceting: ["age"],
+      searchable_attributes: ["full_name"],
+      custom_ranking: ["desc(update_at)"]
+    ]
+
+  defstruct reference: nil, last_name: nil, first_name: nil, age: nil
+
+  def method_to_fetch_index_name do
+    [:people_runtime_index_name_en, :people_runtime_index_name_fr]
+  end
+end

--- a/test/support/schemas/people_struct_with_additional_indexes.ex
+++ b/test/support/schemas/people_struct_with_additional_indexes.ex
@@ -1,0 +1,29 @@
+defmodule Algoliax.Schemas.PeopleStructWithAdditionalIndexes do
+  @moduledoc false
+
+  use Algoliax.Indexer,
+    index_name: [:algoliax_people_struct_en, :algoliax_people_struct_fr],
+    object_id: :reference,
+    algolia: [
+      attributes_for_faceting: ["age"],
+      searchable_attributes: ["full_name"],
+      custom_ranking: ["desc(update_at)"]
+    ]
+
+  defstruct reference: nil, last_name: nil, first_name: nil, age: nil
+
+  def build_object(people) do
+    %{
+      first_name: people.first_name,
+      last_name: people.last_name,
+      age: people.age,
+      updated_at: ~U[2019-01-01 00:00:00Z] |> DateTime.to_unix(),
+      full_name: Map.get(people, :first_name, "") <> " " <> Map.get(people, :last_name, ""),
+      nickname: Map.get(people, :first_name, "") |> String.downcase()
+    }
+  end
+
+  def to_be_indexed?(people) do
+    people.age > 50
+  end
+end

--- a/test/support/schemas/people_with_association_multiple_indexes.ex
+++ b/test/support/schemas/people_with_association_multiple_indexes.ex
@@ -19,7 +19,7 @@ defmodule Algoliax.Schemas.PeopleWithAssociationMultipleIndexes do
       custom_ranking: ["desc(updated_at)"]
     ]
 
-  schema "peoples_with_associations_multiple_indexes" do
+  schema "people_with_associations_multiple_indexes" do
     field(:reference, Ecto.UUID)
     field(:last_name)
     field(:first_name)

--- a/test/support/schemas/people_with_association_multiple_indexes.ex
+++ b/test/support/schemas/people_with_association_multiple_indexes.ex
@@ -1,0 +1,43 @@
+defmodule Algoliax.Schemas.PeopleWithAssociationMultipleIndexes do
+  @moduledoc false
+
+  use Ecto.Schema
+
+  use Algoliax.Indexer,
+    index_name: [
+      :algoliax_people_ecto_with_association_en,
+      :algoliax_people_ecto_with_association_fr
+    ],
+    repo: Algoliax.Repo,
+    object_id: :reference,
+    schemas: [
+      {__MODULE__, [:flowers]}
+    ],
+    algolia: [
+      attributes_for_faceting: ["age", "gender"],
+      searchable_attributes: ["full_name", "gender"],
+      custom_ranking: ["desc(updated_at)"]
+    ]
+
+  schema "peoples_with_associations_multiple_indexes" do
+    field(:reference, Ecto.UUID)
+    field(:last_name)
+    field(:first_name)
+    field(:age, :integer)
+    field(:gender, :string)
+    has_many(:flowers, Algoliax.Schemas.Flower)
+
+    timestamps()
+  end
+
+  def build_object(people) do
+    %{
+      flowers:
+        Enum.map(people.flowers, fn flower ->
+          %{
+            kind: flower.kind
+          }
+        end)
+    }
+  end
+end

--- a/test/support/schemas/people_with_custom_object_id_multiple_indexes.ex
+++ b/test/support/schemas/people_with_custom_object_id_multiple_indexes.ex
@@ -1,0 +1,37 @@
+defmodule Algoliax.Schemas.PeopleWithCustomObjectIdMultipleIndexes do
+  @moduledoc false
+
+  use Ecto.Schema
+
+  use Algoliax.Indexer,
+    index_name: [
+      :algoliax_people_with_custom_object_id_en,
+      :algoliax_people_with_custom_object_id_fr
+    ],
+    repo: Algoliax.Repo,
+    algolia: [
+      attributes_for_faceting: ["age", "gender"],
+      searchable_attributes: ["full_name", "gender"],
+      custom_ranking: ["desc(updated_at)"]
+    ]
+
+  schema "peoples" do
+    field(:reference, Ecto.UUID)
+    field(:last_name)
+    field(:first_name)
+    field(:age, :integer)
+    field(:gender, :string)
+
+    timestamps()
+  end
+
+  def build_object(people) do
+    %{
+      last_name: people.last_name
+    }
+  end
+
+  def get_object_id(people) do
+    "people-" <> people.reference
+  end
+end

--- a/test/support/schemas/people_with_replicas_multiple_indexes.ex
+++ b/test/support/schemas/people_with_replicas_multiple_indexes.ex
@@ -1,0 +1,40 @@
+defmodule Algoliax.Schemas.PeopleWithReplicasMultipleIndexes do
+  @moduledoc false
+
+  use Algoliax.Indexer,
+    index_name: [:algoliax_people_replicas_en, :algoliax_people_replicas_fr],
+    object_id: :reference,
+    algolia: [
+      attributes_for_faceting: ["age"],
+      searchable_attributes: ["full_name"],
+      custom_ranking: ["desc(update_at)"]
+    ],
+    replicas: [
+      [
+        index_name: [:algoliax_people_replicas_asc_en, :algoliax_people_replicas_asc_fr],
+        inherit: true,
+        algolia: [
+          searchable_attributes: ["age"],
+          ranking: ["asc(age)"]
+        ]
+      ],
+      [
+        index_name: [:algoliax_people_replicas_desc_en, :algoliax_people_replicas_desc_fr],
+        inherit: false,
+        algolia: [ranking: ["desc(age)"]]
+      ]
+    ]
+
+  defstruct reference: nil, last_name: nil, first_name: nil, age: nil
+
+  def build_object(people) do
+    %{
+      first_name: people.first_name,
+      last_name: people.last_name,
+      age: people.age,
+      updated_at: ~U[2019-01-01 00:00:00Z] |> DateTime.to_unix(),
+      full_name: Map.get(people, :first_name, "") <> " " <> Map.get(people, :last_name, ""),
+      nickname: Map.get(people, :first_name, "") |> String.downcase()
+    }
+  end
+end

--- a/test/support/schemas/people_with_schemas_multiple_indexes.ex
+++ b/test/support/schemas/people_with_schemas_multiple_indexes.ex
@@ -1,0 +1,35 @@
+defmodule Algoliax.Schemas.PeopleWithSchemasMultipleIndexes do
+  @moduledoc false
+
+  use Ecto.Schema
+
+  alias Algoliax.Schemas.Beer
+
+  use Algoliax.Indexer,
+    index_name: [:algoliax_with_schemas_en, :algoliax_with_schemas_fr],
+    repo: Algoliax.Repo,
+    schemas: [
+      Beer
+    ],
+    algolia: [
+      attributes_for_faceting: ["age", "gender"],
+      searchable_attributes: ["full_name", "gender"],
+      custom_ranking: ["desc(updated_at)"]
+    ]
+
+  schema "peoples" do
+    field(:reference, Ecto.UUID)
+    field(:last_name)
+    field(:first_name)
+    field(:age, :integer)
+    field(:gender, :string)
+
+    timestamps()
+  end
+
+  def build_object(%Beer{} = beer) do
+    %{
+      name: beer.name
+    }
+  end
+end

--- a/test/support/schemas/people_without_id_ecto_multiple_indexes.ex
+++ b/test/support/schemas/people_without_id_ecto_multiple_indexes.ex
@@ -1,0 +1,26 @@
+defmodule Algoliax.Schemas.PeopleWithoutIdEctoMultipleIndexes do
+  @moduledoc false
+
+  use Ecto.Schema
+
+  use Algoliax.Indexer,
+    index_name: [:algoliax_people_without_id_en, :algoliax_people_without_id_fr],
+    repo: Algoliax.Repo,
+    object_id: :reference,
+    cursor_field: :inserted_at,
+    algolia: [
+      attributes_for_faceting: ["age", "gender"],
+      searchable_attributes: ["firstname", "lastname"],
+      custom_ranking: ["desc(updated_at)"]
+    ]
+
+  @primary_key {:reference, Ecto.UUID, autogenerate: true}
+  schema "peoples_without_id" do
+    field(:last_name)
+    field(:first_name)
+    field(:age, :integer)
+    field(:gender, :string)
+
+    timestamps()
+  end
+end


### PR DESCRIPTION
Adds a `build_object/2` with the index name
Adds the possibility to index a same model on multiple indexes (applies for replicas as well)