### PR TITLE
Allow schemas to be a function name. [Fixes #60]

### DIFF
--- a/lib/algoliax/indexer.ex
+++ b/lib/algoliax/indexer.ex
@@ -67,6 +67,21 @@ defmodule Algoliax.Indexer do
 
       end
 
+  The example above will introduce a compile-time dependency on `People` and `Animal`, so it is preferable to provide the name of a function that will return the list of modules.
+
+      defmodule Global do
+        use Algoliax.Indexer,
+          index_name: :people,
+          object_id: :reference,
+          schemas: :index_schemas,
+          algolia: [
+            attribute_for_faceting: ["age"],
+            custom_ranking: ["desc(updated_at)"]
+          ]
+
+        def index_schemas, do: [People, Animal]
+      end
+
     This option allows to define also the preloads use during `reindex`/`reindex_atomic` (preload on `save_object` and `save_objects` have to be done manually)
 
         defmodule People do

--- a/lib/algoliax/resources/object_ecto.ex
+++ b/lib/algoliax/resources/object_ecto.ex
@@ -58,7 +58,7 @@ if Code.ensure_loaded?(Ecto) do
     end
 
     defp fetch_schemas(module, settings) do
-      Algoliax.Utils.schemas(settings, [module])
+      Algoliax.Utils.schemas(module, settings)
       |> Enum.map(fn
         m when is_tuple(m) -> m
         m -> {m, []}

--- a/lib/algoliax/utils.ex
+++ b/lib/algoliax/utils.ex
@@ -30,8 +30,10 @@ defmodule Algoliax.Utils do
     Keyword.get(settings, :object_id, :id)
   end
 
-  def schemas(settings, default) do
-    Keyword.get(settings, :schemas, default)
+  def schemas(module, settings) do
+    with fn_name when is_atom(fn_name) <- Keyword.get(settings, :schemas, [module]) do
+      apply(module, fn_name, [])
+    end
   end
 
   def camelize(params) when is_map(params) do

--- a/test/support/schemas/people_with_schemas.ex
+++ b/test/support/schemas/people_with_schemas.ex
@@ -8,9 +8,7 @@ defmodule Algoliax.Schemas.PeopleWithSchemas do
   use Algoliax.Indexer,
     index_name: :algoliax_with_schemas,
     repo: Algoliax.Repo,
-    schemas: [
-      Beer
-    ],
+    schemas: :indexer_schemas,
     algolia: [
       attributes_for_faceting: ["age", "gender"],
       searchable_attributes: ["full_name", "gender"],
@@ -26,6 +24,8 @@ defmodule Algoliax.Schemas.PeopleWithSchemas do
 
     timestamps()
   end
+
+  def indexer_schemas, do: [Beer]
 
   def build_object(%Beer{} = beer) do
     %{


### PR DESCRIPTION
This PR proposes that `schemas` preference can be a function name, and that this function returns the list of schemas and preloads.

Note that to address the issue, I first tried to "cheat" so that the schemas wouldn't introduce compile-time dependencies (like [phoenix does](https://github.com/phoenixframework/phoenix/blob/v1.6.10/lib/phoenix/controller/pipeline.ex#L200-203)) but that didn't work for preloads with queries, e.g.:

```elixir
[
  {Account, [team_members: from(TeamMember, where: [active: true])]},
]
```

It would thus be possible to avoid the dependency for `Account`, but the `from` will somehow re-introduce the one for `TeamMember` (didn't investigate further).

Fixes #60