### PR TITLE
feat: new default_filters settings for reindex and reindex_atomic

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Test
+export API_MOCK_SERVER_PORT=8002
+export SLACK_MOCK_API_PORT=8002
+export POSTGRES_HOST=localhost
+export POSTGRES_PORT=5432
+export DB_NAME=algoliax_test
+export DB_USERNAME=postgres
+export DB_PASSWORD=postgres
+
+# Run
+export ALGOLIA_API_KEY=
+export ALGOLIA_APPLICATION_ID=

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
+# IDE
+.idea/
+.vscode/
+
+# Env
+.env
+
 # The directory Mix will write compiled artifacts to.
 /_build/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,43 @@
 # Changelog
 
+## v0.8.1 - 2024-01-23
+
+#### New
+
+- Added new **optional** settings `default_filters` to be applied automatically when calling `reindex` without query
+  or `reindex_atomic`. Defaults to `%{}` which was the previous behavior.
+
+```elixir
+defmodule BlondeBeerIndexer do
+  use Algoliax.Indexer,
+    index_name: :blonde_beers,
+    object_id: :name,
+    schemas: [Beer],
+    default_filters: %{where: [kind: "blonde"]}
+end
+
+defmodule BeerIndexer do
+  use Algoliax.Indexer,
+    index_name: :various_beers,
+    object_id: :name,
+    schemas: [Beer1, Beer2],
+    default_filters: :get_filters
+    
+  def get_filters do
+    %{
+      Beer1 => %{where: [kind: "blonde"]}, 
+      Beer2 => %{where: [kind: "brune"]}
+    }
+  end
+end
+```
+
+#### Contributing
+
+- New `CONTRIBUTING.md` file
+- Simplified the `config/test.exs` file
+- Provide a `.env.example` file to help contributors to setup their environment
+
 ## v0.8.0 - 2023-09-20
 
 #### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,20 +13,20 @@ defmodule BlondeBeerIndexer do
     index_name: :blonde_beers,
     object_id: :name,
     schemas: [Beer],
-    default_filters: %{where: [kind: "blonde"]}
+    default_filters: %{where: [kind: "blonde"]} # <---
 end
 
 defmodule BeerIndexer do
   use Algoliax.Indexer,
     index_name: :various_beers,
     object_id: :name,
-    schemas: [Beer1, Beer2],
-    default_filters: :get_filters
+    schemas: [Beer1, Beer2, Beer3],
+    default_filters: :get_filters # <--- can be a function
     
   def get_filters do
     %{
-      Beer1 => %{where: [kind: "blonde"]}, 
-      Beer2 => %{where: [kind: "brune"]}
+      Beer1 => %{where: [kind: "blonde"]},  # <--- custom filter for Beer1
+      :where => [kind: "brune"] # <--- Will be used for Beer2 and Beer3
     }
   end
 end

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+# Contributing
+
+## Install
+
+If you are not using `asdf`, you will need to manually install the program versions listed in `.tool-versions`.
+Otherwise, simply run `asdf install` and then:
+
+```shell
+mix deps.get
+mix deps.compile
+mix compile
+```
+
+## Run tests
+
+Before running `mix test`, ensure you have setup your environment variables.
+Look at the `.env.example` file for the required variables.
+Then run `mix test` to run the tests.
+
+## Quality
+
+- Run `mix format` to format the code.
+- Run `mix credo` to run the linter.
+
+## CI/CD
+
+We use CircleCI to:
+- Run the code_analysis (format/credo)
+- Check for vulnerabilities
+- Run the tests
+
+See the `.circleci/config.yml` file for more details.

--- a/config/test.exs
+++ b/config/test.exs
@@ -7,7 +7,11 @@ config :algoliax,
   ecto_repos: [Algoliax.Repo]
 
 config :algoliax, Algoliax.Repo,
-  database: "algoliax_test",
-  pool: Ecto.Adapters.SQL.Sandbox
+  pool: Ecto.Adapters.SQL.Sandbox,
+  hostname: System.get_env("POSTGRES_HOST", "localhost"),
+  port: System.get_env("POSTGRES_PORT", "5432"),
+  database: System.get_env("DB_NAME", "algoliax_test"),
+  username: System.get_env("DB_USERNAME", "postgres"),
+  password: System.get_env("DB_PASSWORD", "postgres")
 
 config :logger, level: :warning

--- a/lib/algoliax/indexer.ex
+++ b/lib/algoliax/indexer.ex
@@ -8,6 +8,7 @@ defmodule Algoliax.Indexer do
   - `:repo`: Specify an Ecto repo to be use to fecth records. Default `nil`
   - `:cursor_field`: specify the column to be used to order and go through a given table. Default `:id`
   - `:schemas`: Specify which schemas used to populate index, Default: `[__CALLER__]`
+  - `:default_filters`: Specify default filters to be used when reindex without providing a query. Must be a map or a function name (that returns a map). Default: `%{}`.
   - `:algolia`: Any valid Algolia settings, using snake case or camel case. Ex: Algolia `attributeForFaceting` can be configured with `:attribute_for_faceting`
 
   On first call to Algolia, we check that the settings on Algolia are up to date.
@@ -98,6 +99,41 @@ defmodule Algoliax.Indexer do
 
         end
 
+  ### Default filters
+
+  `:default_filters` allows you to define a list of filters that will be automatically applied when performing `reindex` without query, or `reindex_atomic`.
+   If not provided, it defaults to `%{}`, meaning it will not apply any filter and fetch the entire repo for all schemas.
+   You can provide either a map or a function name that returns a map.
+
+      defmodule Global do
+        use Algoliax.Indexer,
+          index_name: :people,
+          object_id: :reference,
+          schemas: [People, Animal],
+          default_filters: %{where: [age: 18]},
+          algolia: [
+            attribute_for_faceting: ["age"],
+            custom_ranking: ["desc(updated_at)"]
+          ]
+      end
+
+  The map must be a valid Ecto query but can be customized/nested by schema:
+
+      defmodule Global do
+        use Algoliax.Indexer,
+          index_name: :people,
+          object_id: :reference,
+          schemas: [People, Animal],
+          default_filters: :get_filters,
+          algolia: [
+            attribute_for_faceting: ["age"],
+            custom_ranking: ["desc(updated_at)"]
+          ]
+
+        def get_filters do
+          %{People => where: [age: 18], Animal => where: [kind: "cat"]}
+        end
+      end
   """
 
   alias Algoliax.Resources.{Index, Object, Search}

--- a/lib/algoliax/indexer.ex
+++ b/lib/algoliax/indexer.ex
@@ -131,7 +131,9 @@ defmodule Algoliax.Indexer do
           ]
 
         def get_filters do
-          %{People => where: [age: 18], Animal => where: [kind: "cat"]}
+          %{
+            People => where: [age: 18], # <-- Custom filter for People
+            :where => [kind: "cat"]  # <-- Default filter for other schemas
         end
       end
   """

--- a/lib/algoliax/utils.ex
+++ b/lib/algoliax/utils.ex
@@ -36,6 +36,16 @@ defmodule Algoliax.Utils do
     Keyword.get(settings, :object_id, :id)
   end
 
+  def default_filters(module, settings) do
+    case Keyword.get(settings, :default_filters, %{}) do
+      fn_name when is_atom(fn_name) ->
+        apply(module, fn_name, [])
+
+      default_filters ->
+        default_filters
+    end
+  end
+
   def schemas(module, settings) do
     with fn_name when is_atom(fn_name) <- Keyword.get(settings, :schemas, [module]) do
       apply(module, fn_name, [])

--- a/test/algoliax/schema_test.exs
+++ b/test/algoliax/schema_test.exs
@@ -14,6 +14,8 @@ defmodule AlgoliaxTest.Schema do
   alias Algoliax.Schemas.{
     Animal,
     Beer,
+    BeerWithFilters,
+    BeerWithSchemaFilters,
     Flower,
     PeopleEcto,
     PeopleEctoMultipleIndexes,
@@ -175,661 +177,673 @@ defmodule AlgoliaxTest.Schema do
     :ok
   end
 
-  test "reindex" do
-    assert {:ok, [{:ok, %Algoliax.Response{}}, {:ok, %Algoliax.Response{}}]} =
-             PeopleEcto.reindex()
+  describe "reindex" do
+    test "reindex" do
+      assert {:ok, [{:ok, %Algoliax.Response{}}, {:ok, %Algoliax.Response{}}]} =
+               PeopleEcto.reindex()
 
-    assert_request("POST", %{
-      "requests" => [
-        %{
-          "action" => "updateObject",
-          "body" => %{
-            "objectID" => @ref1,
-            "last_name" => "Doe",
-            "first_name" => "John",
-            "age" => 77
+      assert_request("POST", %{
+        "requests" => [
+          %{
+            "action" => "updateObject",
+            "body" => %{
+              "objectID" => @ref1,
+              "last_name" => "Doe",
+              "first_name" => "John",
+              "age" => 77
+            }
           }
-        }
-      ]
-    })
+        ]
+      })
 
-    assert_request("POST", %{
-      "requests" => [
-        %{
-          "action" => "updateObject",
-          "body" => %{
-            "objectID" => @ref2,
-            "last_name" => "al",
-            "first_name" => "bert",
-            "age" => 35
+      assert_request("POST", %{
+        "requests" => [
+          %{
+            "action" => "updateObject",
+            "body" => %{
+              "objectID" => @ref2,
+              "last_name" => "al",
+              "first_name" => "bert",
+              "age" => 35
+            }
           }
-        }
-      ]
-    })
-  end
-
-  test "reindex multiple indexes" do
-    assert {:ok,
-            [
-              %Algoliax.Responses{
-                index_name: :algoliax_people_en,
-                responses: [{:ok, %Algoliax.Response{}}, {:ok, %Algoliax.Response{}}]
-              },
-              %Algoliax.Responses{
-                index_name: :algoliax_people_fr,
-                responses: [{:ok, %Algoliax.Response{}}, {:ok, %Algoliax.Response{}}]
-              }
-            ]} = PeopleEctoMultipleIndexes.reindex()
-
-    assert_request("POST", ~r/algoliax_people_en/, %{
-      "requests" => [
-        %{
-          "action" => "updateObject",
-          "body" => %{
-            "objectID" => @ref1,
-            "last_name" => "Doe",
-            "first_name" => "John",
-            "age" => 77
-          }
-        }
-      ]
-    })
-
-    assert_request("POST", ~r/algoliax_people_en/, %{
-      "requests" => [
-        %{
-          "action" => "updateObject",
-          "body" => %{
-            "objectID" => @ref2,
-            "last_name" => "al",
-            "first_name" => "bert",
-            "age" => 35
-          }
-        }
-      ]
-    })
-
-    assert_request("POST", ~r/algoliax_people_fr/, %{
-      "requests" => [
-        %{
-          "action" => "updateObject",
-          "body" => %{
-            "objectID" => @ref1,
-            "last_name" => "Doe",
-            "first_name" => "John",
-            "age" => 77
-          }
-        }
-      ]
-    })
-
-    assert_request("POST", ~r/algoliax_people_fr/, %{
-      "requests" => [
-        %{
-          "action" => "updateObject",
-          "body" => %{
-            "objectID" => @ref2,
-            "last_name" => "al",
-            "first_name" => "bert",
-            "age" => 35
-          }
-        }
-      ]
-    })
-  end
-
-  test "reindex with force delete" do
-    assert {:ok,
-            [
-              {:ok, %Algoliax.Response{}},
-              {:ok, %Algoliax.Response{}},
-              {:ok, %Algoliax.Response{}}
-            ]} = PeopleEcto.reindex(force_delete: true)
-
-    assert_request("POST", %{
-      "requests" => [
-        %{"action" => "updateObject", "body" => %{"objectID" => @ref1}}
-      ]
-    })
-
-    assert_request("POST", %{
-      "requests" => [
-        %{"action" => "updateObject", "body" => %{"objectID" => @ref2}}
-      ]
-    })
-
-    assert_request("POST", %{
-      "requests" => [
-        %{"action" => "deleteObject", "body" => %{"objectID" => @ref3}}
-      ]
-    })
-  end
-
-  test "reindex multiple indexes with force delete" do
-    assert {:ok,
-            [
-              %Algoliax.Responses{
-                index_name: :algoliax_people_en,
-                responses: [
-                  {:ok, %Algoliax.Response{}},
-                  {:ok, %Algoliax.Response{}},
-                  {:ok, %Algoliax.Response{}}
-                ]
-              },
-              %Algoliax.Responses{
-                index_name: :algoliax_people_fr,
-                responses: [
-                  {:ok, %Algoliax.Response{}},
-                  {:ok, %Algoliax.Response{}},
-                  {:ok, %Algoliax.Response{}}
-                ]
-              }
-            ]} = PeopleEctoMultipleIndexes.reindex(force_delete: true)
-
-    assert_request("POST", ~r/algoliax_people_en/, %{
-      "requests" => [
-        %{"action" => "updateObject", "body" => %{"objectID" => @ref1}}
-      ]
-    })
-
-    assert_request("POST", ~r/algoliax_people_en/, %{
-      "requests" => [
-        %{"action" => "updateObject", "body" => %{"objectID" => @ref2}}
-      ]
-    })
-
-    assert_request("POST", ~r/algoliax_people_en/, %{
-      "requests" => [
-        %{"action" => "deleteObject", "body" => %{"objectID" => @ref3}}
-      ]
-    })
-
-    assert_request("POST", ~r/algoliax_people_fr/, %{
-      "requests" => [
-        %{"action" => "updateObject", "body" => %{"objectID" => @ref1}}
-      ]
-    })
-
-    assert_request("POST", ~r/algoliax_people_fr/, %{
-      "requests" => [
-        %{"action" => "updateObject", "body" => %{"objectID" => @ref2}}
-      ]
-    })
-
-    assert_request("POST", ~r/algoliax_people_fr/, %{
-      "requests" => [
-        %{"action" => "deleteObject", "body" => %{"objectID" => @ref3}}
-      ]
-    })
-  end
-
-  test "reindex with query" do
-    query =
-      from(p in PeopleEcto,
-        where: p.age == 35
-      )
-
-    assert {:ok, [{:ok, %Algoliax.Response{}}]} = PeopleEcto.reindex(query)
-
-    assert_request("POST", %{
-      "requests" => [
-        %{"action" => "updateObject", "body" => %{"objectID" => @ref2}}
-      ]
-    })
-  end
-
-  test "reindex nothing as no result" do
-    query =
-      from(p in PeopleEcto,
-        where: p.age == 999
-      )
-
-    assert {:ok, []} = PeopleEcto.reindex(query)
-  end
-
-  test "reindex multiple indexes with query" do
-    query =
-      from(p in PeopleEctoMultipleIndexes,
-        where: p.age == 35
-      )
-
-    assert {:ok,
-            [
-              %Algoliax.Responses{
-                index_name: :algoliax_people_en,
-                responses: [
-                  {:ok, %Algoliax.Response{}}
-                ]
-              },
-              %Algoliax.Responses{
-                index_name: :algoliax_people_fr,
-                responses: [
-                  {:ok, %Algoliax.Response{}}
-                ]
-              }
-            ]} = PeopleEctoMultipleIndexes.reindex(query)
-
-    assert_request("POST", ~r/algoliax_people_en/, %{
-      "requests" => [
-        %{"action" => "updateObject", "body" => %{"objectID" => @ref2}}
-      ]
-    })
-
-    assert_request("POST", ~r/algoliax_people_fr/, %{
-      "requests" => [
-        %{"action" => "updateObject", "body" => %{"objectID" => @ref2}}
-      ]
-    })
-  end
-
-  test "reindex with query and force delete" do
-    query =
-      from(p in PeopleEcto,
-        where: p.age == 35 or p.first_name == "Dark"
-      )
-
-    assert {:ok,
-            [
-              {:ok, %Algoliax.Response{}},
-              {:ok, %Algoliax.Response{}}
-            ]} = PeopleEcto.reindex(query, force_delete: true)
-
-    assert_request("POST", %{
-      "requests" => [
-        %{"action" => "updateObject", "body" => %{"objectID" => @ref2}}
-      ]
-    })
-
-    assert_request("POST", %{
-      "requests" => [
-        %{"action" => "deleteObject", "body" => %{"objectID" => @ref3}}
-      ]
-    })
-  end
-
-  test "reindex multiple indexes with query and force delete" do
-    query =
-      from(p in PeopleEctoMultipleIndexes,
-        where: p.age == 35 or p.first_name == "Dark"
-      )
-
-    assert {:ok,
-            [
-              %Algoliax.Responses{
-                index_name: :algoliax_people_en,
-                responses: [
-                  {:ok, %Algoliax.Response{}},
-                  {:ok, %Algoliax.Response{}}
-                ]
-              },
-              %Algoliax.Responses{
-                index_name: :algoliax_people_fr,
-                responses: [
-                  {:ok, %Algoliax.Response{}},
-                  {:ok, %Algoliax.Response{}}
-                ]
-              }
-            ]} = PeopleEctoMultipleIndexes.reindex(query, force_delete: true)
-
-    assert_request("POST", ~r/algoliax_people_en/, %{
-      "requests" => [
-        %{"action" => "updateObject", "body" => %{"objectID" => @ref2}}
-      ]
-    })
-
-    assert_request("POST", ~r/algoliax_people_fr/, %{
-      "requests" => [
-        %{"action" => "updateObject", "body" => %{"objectID" => @ref2}}
-      ]
-    })
-
-    assert_request("POST", ~r/algoliax_people_en/, %{
-      "requests" => [
-        %{"action" => "deleteObject", "body" => %{"objectID" => @ref3}}
-      ]
-    })
-
-    assert_request("POST", ~r/algoliax_people_fr/, %{
-      "requests" => [
-        %{"action" => "deleteObject", "body" => %{"objectID" => @ref3}}
-      ]
-    })
-  end
-
-  test "reindex atomic" do
-    assert {:ok, :completed} = PeopleEcto.reindex_atomic()
-
-    assert_request("POST", %{
-      "requests" => [
-        %{"action" => "updateObject", "body" => %{"objectID" => @ref1}}
-      ]
-    })
-
-    assert_request("POST", %{
-      "requests" => [
-        %{"action" => "updateObject", "body" => %{"objectID" => @ref2}}
-      ]
-    })
-
-    assert_request("POST", ~r/algoliax_people\.tmp/, %{
-      "destination" => "algoliax_people",
-      "operation" => "move"
-    })
-  end
-
-  test "reindex atomic for multiple indexes" do
-    assert [{:ok, :completed}, {:ok, :completed}] = PeopleEctoMultipleIndexes.reindex_atomic()
-
-    assert_request("POST", ~r/algoliax_people_en/, %{
-      "requests" => [
-        %{"action" => "updateObject", "body" => %{"objectID" => @ref1}}
-      ]
-    })
-
-    assert_request("POST", ~r/algoliax_people_fr/, %{
-      "requests" => [
-        %{"action" => "updateObject", "body" => %{"objectID" => @ref1}}
-      ]
-    })
-
-    assert_request("POST", ~r/algoliax_people_en/, %{
-      "requests" => [
-        %{"action" => "updateObject", "body" => %{"objectID" => @ref2}}
-      ]
-    })
-
-    assert_request("POST", ~r/algoliax_people_fr/, %{
-      "requests" => [
-        %{"action" => "updateObject", "body" => %{"objectID" => @ref2}}
-      ]
-    })
-
-    assert_request("POST", ~r/algoliax_people_en\.tmp/, %{
-      "destination" => "algoliax_people_en",
-      "operation" => "move"
-    })
-
-    assert_request("POST", ~r/algoliax_people_fr\.tmp/, %{
-      "destination" => "algoliax_people_fr",
-      "operation" => "move"
-    })
-  end
-
-  test "reindex atomic with fail" do
-    assert_raise Postgrex.Error, fn ->
-      PeopleEctoFail.reindex_atomic()
+        ]
+      })
     end
 
-    assert_request("DELETE", ~r/algoliax_people_fail\.tmp/, %{})
-    refute Algoliax.SettingsStore.reindexing?(:algoliax_people_fail)
-  end
+    test "with multiple indexes" do
+      assert {:ok,
+              [
+                %Algoliax.Responses{
+                  index_name: :algoliax_people_en,
+                  responses: [{:ok, %Algoliax.Response{}}, {:ok, %Algoliax.Response{}}]
+                },
+                %Algoliax.Responses{
+                  index_name: :algoliax_people_fr,
+                  responses: [{:ok, %Algoliax.Response{}}, {:ok, %Algoliax.Response{}}]
+                }
+              ]} = PeopleEctoMultipleIndexes.reindex()
 
-  test "reindex multiple indexes atomic with fail" do
-    assert_raise Postgrex.Error, fn ->
-      PeopleEctoFailMultipleIndexes.reindex_atomic()
+      assert_request("POST", ~r/algoliax_people_en/, %{
+        "requests" => [
+          %{
+            "action" => "updateObject",
+            "body" => %{
+              "objectID" => @ref1,
+              "last_name" => "Doe",
+              "first_name" => "John",
+              "age" => 77
+            }
+          }
+        ]
+      })
+
+      assert_request("POST", ~r/algoliax_people_en/, %{
+        "requests" => [
+          %{
+            "action" => "updateObject",
+            "body" => %{
+              "objectID" => @ref2,
+              "last_name" => "al",
+              "first_name" => "bert",
+              "age" => 35
+            }
+          }
+        ]
+      })
+
+      assert_request("POST", ~r/algoliax_people_fr/, %{
+        "requests" => [
+          %{
+            "action" => "updateObject",
+            "body" => %{
+              "objectID" => @ref1,
+              "last_name" => "Doe",
+              "first_name" => "John",
+              "age" => 77
+            }
+          }
+        ]
+      })
+
+      assert_request("POST", ~r/algoliax_people_fr/, %{
+        "requests" => [
+          %{
+            "action" => "updateObject",
+            "body" => %{
+              "objectID" => @ref2,
+              "last_name" => "al",
+              "first_name" => "bert",
+              "age" => 35
+            }
+          }
+        ]
+      })
     end
 
-    assert_request("DELETE", ~r/algoliax_people_fail_en\.tmp/, %{})
-    refute Algoliax.SettingsStore.reindexing?(:algoliax_people_fail_en)
-    refute Algoliax.SettingsStore.reindexing?(:algoliax_people_fail_fr)
+    test "with force delete" do
+      assert {:ok,
+              [
+                {:ok, %Algoliax.Response{}},
+                {:ok, %Algoliax.Response{}},
+                {:ok, %Algoliax.Response{}}
+              ]} = PeopleEcto.reindex(force_delete: true)
+
+      assert_request("POST", %{
+        "requests" => [
+          %{"action" => "updateObject", "body" => %{"objectID" => @ref1}}
+        ]
+      })
+
+      assert_request("POST", %{
+        "requests" => [
+          %{"action" => "updateObject", "body" => %{"objectID" => @ref2}}
+        ]
+      })
+
+      assert_request("POST", %{
+        "requests" => [
+          %{"action" => "deleteObject", "body" => %{"objectID" => @ref3}}
+        ]
+      })
+    end
+
+    test "with multiple indexes and with force delete" do
+      assert {:ok,
+              [
+                %Algoliax.Responses{
+                  index_name: :algoliax_people_en,
+                  responses: [
+                    {:ok, %Algoliax.Response{}},
+                    {:ok, %Algoliax.Response{}},
+                    {:ok, %Algoliax.Response{}}
+                  ]
+                },
+                %Algoliax.Responses{
+                  index_name: :algoliax_people_fr,
+                  responses: [
+                    {:ok, %Algoliax.Response{}},
+                    {:ok, %Algoliax.Response{}},
+                    {:ok, %Algoliax.Response{}}
+                  ]
+                }
+              ]} = PeopleEctoMultipleIndexes.reindex(force_delete: true)
+
+      assert_request("POST", ~r/algoliax_people_en/, %{
+        "requests" => [
+          %{"action" => "updateObject", "body" => %{"objectID" => @ref1}}
+        ]
+      })
+
+      assert_request("POST", ~r/algoliax_people_en/, %{
+        "requests" => [
+          %{"action" => "updateObject", "body" => %{"objectID" => @ref2}}
+        ]
+      })
+
+      assert_request("POST", ~r/algoliax_people_en/, %{
+        "requests" => [
+          %{"action" => "deleteObject", "body" => %{"objectID" => @ref3}}
+        ]
+      })
+
+      assert_request("POST", ~r/algoliax_people_fr/, %{
+        "requests" => [
+          %{"action" => "updateObject", "body" => %{"objectID" => @ref1}}
+        ]
+      })
+
+      assert_request("POST", ~r/algoliax_people_fr/, %{
+        "requests" => [
+          %{"action" => "updateObject", "body" => %{"objectID" => @ref2}}
+        ]
+      })
+
+      assert_request("POST", ~r/algoliax_people_fr/, %{
+        "requests" => [
+          %{"action" => "deleteObject", "body" => %{"objectID" => @ref3}}
+        ]
+      })
+    end
+
+    test "with query" do
+      query =
+        from(p in PeopleEcto,
+          where: p.age == 35
+        )
+
+      assert {:ok, [{:ok, %Algoliax.Response{}}]} = PeopleEcto.reindex(query)
+
+      assert_request("POST", %{
+        "requests" => [
+          %{"action" => "updateObject", "body" => %{"objectID" => @ref2}}
+        ]
+      })
+    end
+
+    test "with nothing as no result" do
+      query =
+        from(p in PeopleEcto,
+          where: p.age == 999
+        )
+
+      assert {:ok, []} = PeopleEcto.reindex(query)
+    end
+
+    test "with multiple indexes and with query" do
+      query =
+        from(p in PeopleEctoMultipleIndexes,
+          where: p.age == 35
+        )
+
+      assert {:ok,
+              [
+                %Algoliax.Responses{
+                  index_name: :algoliax_people_en,
+                  responses: [
+                    {:ok, %Algoliax.Response{}}
+                  ]
+                },
+                %Algoliax.Responses{
+                  index_name: :algoliax_people_fr,
+                  responses: [
+                    {:ok, %Algoliax.Response{}}
+                  ]
+                }
+              ]} = PeopleEctoMultipleIndexes.reindex(query)
+
+      assert_request("POST", ~r/algoliax_people_en/, %{
+        "requests" => [
+          %{"action" => "updateObject", "body" => %{"objectID" => @ref2}}
+        ]
+      })
+
+      assert_request("POST", ~r/algoliax_people_fr/, %{
+        "requests" => [
+          %{"action" => "updateObject", "body" => %{"objectID" => @ref2}}
+        ]
+      })
+    end
+
+    test "with query and force delete" do
+      query =
+        from(p in PeopleEcto,
+          where: p.age == 35 or p.first_name == "Dark"
+        )
+
+      assert {:ok,
+              [
+                {:ok, %Algoliax.Response{}},
+                {:ok, %Algoliax.Response{}}
+              ]} = PeopleEcto.reindex(query, force_delete: true)
+
+      assert_request("POST", %{
+        "requests" => [
+          %{"action" => "updateObject", "body" => %{"objectID" => @ref2}}
+        ]
+      })
+
+      assert_request("POST", %{
+        "requests" => [
+          %{"action" => "deleteObject", "body" => %{"objectID" => @ref3}}
+        ]
+      })
+    end
+
+    test "multiple indexes with query and force delete" do
+      query =
+        from(p in PeopleEctoMultipleIndexes,
+          where: p.age == 35 or p.first_name == "Dark"
+        )
+
+      assert {:ok,
+              [
+                %Algoliax.Responses{
+                  index_name: :algoliax_people_en,
+                  responses: [
+                    {:ok, %Algoliax.Response{}},
+                    {:ok, %Algoliax.Response{}}
+                  ]
+                },
+                %Algoliax.Responses{
+                  index_name: :algoliax_people_fr,
+                  responses: [
+                    {:ok, %Algoliax.Response{}},
+                    {:ok, %Algoliax.Response{}}
+                  ]
+                }
+              ]} = PeopleEctoMultipleIndexes.reindex(query, force_delete: true)
+
+      assert_request("POST", ~r/algoliax_people_en/, %{
+        "requests" => [
+          %{"action" => "updateObject", "body" => %{"objectID" => @ref2}}
+        ]
+      })
+
+      assert_request("POST", ~r/algoliax_people_fr/, %{
+        "requests" => [
+          %{"action" => "updateObject", "body" => %{"objectID" => @ref2}}
+        ]
+      })
+
+      assert_request("POST", ~r/algoliax_people_en/, %{
+        "requests" => [
+          %{"action" => "deleteObject", "body" => %{"objectID" => @ref3}}
+        ]
+      })
+
+      assert_request("POST", ~r/algoliax_people_fr/, %{
+        "requests" => [
+          %{"action" => "deleteObject", "body" => %{"objectID" => @ref3}}
+        ]
+      })
+    end
   end
 
-  test "reindex without an id column" do
-    assert {:ok,
-            [
-              {:ok, %Algoliax.Response{}},
-              {:ok, %Algoliax.Response{}},
-              {:ok, %Algoliax.Response{}}
-            ]} = PeopleWithoutIdEcto.reindex()
+  describe "reindex atomic" do
+    test "reindex atomic" do
+      assert {:ok, :completed} = PeopleEcto.reindex_atomic()
 
-    assert_request("POST", %{
-      "requests" => [
-        %{"action" => "updateObject", "body" => %{"objectID" => @ref1}}
-      ]
-    })
+      assert_request("POST", %{
+        "requests" => [
+          %{"action" => "updateObject", "body" => %{"objectID" => @ref1}}
+        ]
+      })
 
-    assert_request("POST", %{
-      "requests" => [
-        %{"action" => "updateObject", "body" => %{"objectID" => @ref2}}
-      ]
-    })
+      assert_request("POST", %{
+        "requests" => [
+          %{"action" => "updateObject", "body" => %{"objectID" => @ref2}}
+        ]
+      })
 
-    assert_request("POST", %{
-      "requests" => [
-        %{"action" => "updateObject", "body" => %{"objectID" => @ref3}}
-      ]
-    })
+      assert_request("POST", ~r/algoliax_people\.tmp/, %{
+        "destination" => "algoliax_people",
+        "operation" => "move"
+      })
+    end
+
+    test "with multiple indexes" do
+      assert [{:ok, :completed}, {:ok, :completed}] = PeopleEctoMultipleIndexes.reindex_atomic()
+
+      assert_request("POST", ~r/algoliax_people_en/, %{
+        "requests" => [
+          %{"action" => "updateObject", "body" => %{"objectID" => @ref1}}
+        ]
+      })
+
+      assert_request("POST", ~r/algoliax_people_fr/, %{
+        "requests" => [
+          %{"action" => "updateObject", "body" => %{"objectID" => @ref1}}
+        ]
+      })
+
+      assert_request("POST", ~r/algoliax_people_en/, %{
+        "requests" => [
+          %{"action" => "updateObject", "body" => %{"objectID" => @ref2}}
+        ]
+      })
+
+      assert_request("POST", ~r/algoliax_people_fr/, %{
+        "requests" => [
+          %{"action" => "updateObject", "body" => %{"objectID" => @ref2}}
+        ]
+      })
+
+      assert_request("POST", ~r/algoliax_people_en\.tmp/, %{
+        "destination" => "algoliax_people_en",
+        "operation" => "move"
+      })
+
+      assert_request("POST", ~r/algoliax_people_fr\.tmp/, %{
+        "destination" => "algoliax_people_fr",
+        "operation" => "move"
+      })
+    end
+
+    test "with fail" do
+      assert_raise Postgrex.Error, fn ->
+        PeopleEctoFail.reindex_atomic()
+      end
+
+      assert_request("DELETE", ~r/algoliax_people_fail\.tmp/, %{})
+      refute Algoliax.SettingsStore.reindexing?(:algoliax_people_fail)
+    end
+
+    test "with multiple indexes atomic with fail" do
+      assert_raise Postgrex.Error, fn ->
+        PeopleEctoFailMultipleIndexes.reindex_atomic()
+      end
+
+      assert_request("DELETE", ~r/algoliax_people_fail_en\.tmp/, %{})
+      refute Algoliax.SettingsStore.reindexing?(:algoliax_people_fail_en)
+      refute Algoliax.SettingsStore.reindexing?(:algoliax_people_fail_fr)
+    end
   end
 
-  test "reindex multiple indexes without an id column" do
-    assert {:ok,
-            [
-              %Algoliax.Responses{
-                index_name: :algoliax_people_without_id_en,
-                responses: [
-                  {:ok, %Algoliax.Response{}},
-                  {:ok, %Algoliax.Response{}},
-                  {:ok, %Algoliax.Response{}}
-                ]
-              },
-              %Algoliax.Responses{
-                index_name: :algoliax_people_without_id_fr,
-                responses: [
-                  {:ok, %Algoliax.Response{}},
-                  {:ok, %Algoliax.Response{}},
-                  {:ok, %Algoliax.Response{}}
-                ]
-              }
-            ]} = PeopleWithoutIdEctoMultipleIndexes.reindex()
+  describe "reindex without an id column" do
+    test "reindex" do
+      assert {:ok,
+              [
+                {:ok, %Algoliax.Response{}},
+                {:ok, %Algoliax.Response{}},
+                {:ok, %Algoliax.Response{}}
+              ]} = PeopleWithoutIdEcto.reindex()
 
-    assert_request("POST", ~r/algoliax_people_without_id_en/, %{
-      "requests" => [
-        %{"action" => "updateObject", "body" => %{"objectID" => @ref1}}
-      ]
-    })
+      assert_request("POST", %{
+        "requests" => [
+          %{"action" => "updateObject", "body" => %{"objectID" => @ref1}}
+        ]
+      })
 
-    assert_request("POST", ~r/algoliax_people_without_id_en/, %{
-      "requests" => [
-        %{"action" => "updateObject", "body" => %{"objectID" => @ref2}}
-      ]
-    })
+      assert_request("POST", %{
+        "requests" => [
+          %{"action" => "updateObject", "body" => %{"objectID" => @ref2}}
+        ]
+      })
 
-    assert_request("POST", ~r/algoliax_people_without_id_en/, %{
-      "requests" => [
-        %{"action" => "updateObject", "body" => %{"objectID" => @ref3}}
-      ]
-    })
+      assert_request("POST", %{
+        "requests" => [
+          %{"action" => "updateObject", "body" => %{"objectID" => @ref3}}
+        ]
+      })
+    end
 
-    assert_request("POST", ~r/algoliax_people_without_id_fr/, %{
-      "requests" => [
-        %{"action" => "updateObject", "body" => %{"objectID" => @ref1}}
-      ]
-    })
+    test "with mutiple indexes" do
+      assert {:ok,
+              [
+                %Algoliax.Responses{
+                  index_name: :algoliax_people_without_id_en,
+                  responses: [
+                    {:ok, %Algoliax.Response{}},
+                    {:ok, %Algoliax.Response{}},
+                    {:ok, %Algoliax.Response{}}
+                  ]
+                },
+                %Algoliax.Responses{
+                  index_name: :algoliax_people_without_id_fr,
+                  responses: [
+                    {:ok, %Algoliax.Response{}},
+                    {:ok, %Algoliax.Response{}},
+                    {:ok, %Algoliax.Response{}}
+                  ]
+                }
+              ]} = PeopleWithoutIdEctoMultipleIndexes.reindex()
 
-    assert_request("POST", ~r/algoliax_people_without_id_fr/, %{
-      "requests" => [
-        %{"action" => "updateObject", "body" => %{"objectID" => @ref2}}
-      ]
-    })
+      assert_request("POST", ~r/algoliax_people_without_id_en/, %{
+        "requests" => [
+          %{"action" => "updateObject", "body" => %{"objectID" => @ref1}}
+        ]
+      })
 
-    assert_request("POST", ~r/algoliax_people_without_id_fr/, %{
-      "requests" => [
-        %{"action" => "updateObject", "body" => %{"objectID" => @ref3}}
-      ]
-    })
+      assert_request("POST", ~r/algoliax_people_without_id_en/, %{
+        "requests" => [
+          %{"action" => "updateObject", "body" => %{"objectID" => @ref2}}
+        ]
+      })
+
+      assert_request("POST", ~r/algoliax_people_without_id_en/, %{
+        "requests" => [
+          %{"action" => "updateObject", "body" => %{"objectID" => @ref3}}
+        ]
+      })
+
+      assert_request("POST", ~r/algoliax_people_without_id_fr/, %{
+        "requests" => [
+          %{"action" => "updateObject", "body" => %{"objectID" => @ref1}}
+        ]
+      })
+
+      assert_request("POST", ~r/algoliax_people_without_id_fr/, %{
+        "requests" => [
+          %{"action" => "updateObject", "body" => %{"objectID" => @ref2}}
+        ]
+      })
+
+      assert_request("POST", ~r/algoliax_people_without_id_fr/, %{
+        "requests" => [
+          %{"action" => "updateObject", "body" => %{"objectID" => @ref3}}
+        ]
+      })
+    end
   end
 
-  test "save_object/1 without attribute(s)" do
-    assert {:ok, _} = PeopleWithSchemas.save_object(%Beer{kind: "brune", name: "chimay", id: 1})
+  describe "save_objects" do
+    test "without attribute(s)" do
+      assert {:ok, _} = PeopleWithSchemas.save_object(%Beer{kind: "brune", name: "chimay", id: 1})
 
-    assert_request("PUT", %{
-      "name" => "chimay",
-      "objectID" => 1
-    })
+      assert_request("PUT", %{
+        "name" => "chimay",
+        "objectID" => 1
+      })
+    end
+
+    test "without attribute(s) and with multiple indexes" do
+      assert {:ok, [%Algoliax.Responses{}, %Algoliax.Responses{}]} =
+               PeopleWithSchemasMultipleIndexes.save_object(%Beer{
+                 kind: "brune",
+                 name: "chimay",
+                 id: 1
+               })
+
+      assert_request("PUT", ~r/algoliax_with_schemas_en/, %{
+        "name" => "chimay",
+        "objectID" => 1
+      })
+
+      assert_request("PUT", ~r/algoliax_with_schemas_fr/, %{
+        "name" => "chimay",
+        "objectID" => 1
+      })
+    end
   end
 
-  test "save_object/1 without attribute(s) and multiple indexes" do
-    assert {:ok, [%Algoliax.Responses{}, %Algoliax.Responses{}]} =
-             PeopleWithSchemasMultipleIndexes.save_object(%Beer{
-               kind: "brune",
-               name: "chimay",
-               id: 1
-             })
+  describe "reindex with schemas" do
+    test "reindex" do
+      assert PeopleWithSchemas.reindex()
 
-    assert_request("PUT", ~r/algoliax_with_schemas_en/, %{
-      "name" => "chimay",
-      "objectID" => 1
-    })
+      assert_request("POST", %{
+        "requests" => [
+          %{"action" => "updateObject", "body" => %{"name" => "chimay", "objectID" => 1}}
+        ]
+      })
 
-    assert_request("PUT", ~r/algoliax_with_schemas_fr/, %{
-      "name" => "chimay",
-      "objectID" => 1
-    })
+      assert_request("POST", %{
+        "requests" => [
+          %{"action" => "updateObject", "body" => %{"name" => "jupiler", "objectID" => 2}}
+        ]
+      })
+    end
+
+    test "with multiple indexes" do
+      assert PeopleWithSchemasMultipleIndexes.reindex()
+
+      assert_request("POST", ~r/algoliax_with_schemas_en/, %{
+        "requests" => [
+          %{"action" => "updateObject", "body" => %{"name" => "chimay", "objectID" => 1}}
+        ]
+      })
+
+      assert_request("POST", ~r/algoliax_with_schemas_en/, %{
+        "requests" => [
+          %{"action" => "updateObject", "body" => %{"name" => "jupiler", "objectID" => 2}}
+        ]
+      })
+
+      assert_request("POST", ~r/algoliax_with_schemas_fr/, %{
+        "requests" => [
+          %{"action" => "updateObject", "body" => %{"name" => "chimay", "objectID" => 1}}
+        ]
+      })
+
+      assert_request("POST", ~r/algoliax_with_schemas_fr/, %{
+        "requests" => [
+          %{"action" => "updateObject", "body" => %{"name" => "jupiler", "objectID" => 2}}
+        ]
+      })
+    end
+
+    test "with query" do
+      query =
+        from(b in Beer,
+          where: b.name == "chimay"
+        )
+
+      assert {:ok, _} = PeopleWithSchemas.reindex(query)
+
+      assert_request("POST", %{
+        "requests" => [
+          %{"action" => "updateObject", "body" => %{"name" => "chimay", "objectID" => 1}}
+        ]
+      })
+    end
+
+    test "with query and multiple indexes" do
+      query =
+        from(b in Beer,
+          where: b.name == "chimay"
+        )
+
+      assert {:ok,
+              [
+                %Algoliax.Responses{
+                  index_name: :algoliax_with_schemas_en,
+                  responses: [
+                    {:ok, %Algoliax.Response{}}
+                  ]
+                },
+                %Algoliax.Responses{
+                  index_name: :algoliax_with_schemas_fr,
+                  responses: [
+                    {:ok, %Algoliax.Response{}}
+                  ]
+                }
+              ]} = PeopleWithSchemasMultipleIndexes.reindex(query)
+
+      assert_request("POST", ~r/algoliax_with_schemas_en/, %{
+        "requests" => [
+          %{"action" => "updateObject", "body" => %{"name" => "chimay", "objectID" => 1}}
+        ]
+      })
+
+      assert_request("POST", ~r/algoliax_with_schemas_fr/, %{
+        "requests" => [
+          %{"action" => "updateObject", "body" => %{"name" => "chimay", "objectID" => 1}}
+        ]
+      })
+    end
+
+    test "with query as keyword list" do
+      query = %{where: [name: "heineken"]}
+      assert {:ok, _} = PeopleWithSchemas.reindex(query)
+
+      assert_request("POST", %{
+        "requests" => [
+          %{"action" => "updateObject", "body" => %{"name" => "heineken", "objectID" => 3}}
+        ]
+      })
+    end
+
+    test "with query as keyword list and multiple indexes" do
+      query = %{where: [name: "heineken"]}
+
+      assert {:ok,
+              [
+                %Algoliax.Responses{
+                  index_name: :algoliax_with_schemas_en,
+                  responses: [
+                    {:ok, %Algoliax.Response{}}
+                  ]
+                },
+                %Algoliax.Responses{
+                  index_name: :algoliax_with_schemas_fr,
+                  responses: [
+                    {:ok, %Algoliax.Response{}}
+                  ]
+                }
+              ]} = PeopleWithSchemasMultipleIndexes.reindex(query)
+
+      assert_request("POST", ~r/algoliax_with_schemas_en/, %{
+        "requests" => [
+          %{"action" => "updateObject", "body" => %{"name" => "heineken", "objectID" => 3}}
+        ]
+      })
+
+      assert_request("POST", ~r/algoliax_with_schemas_fr/, %{
+        "requests" => [
+          %{"action" => "updateObject", "body" => %{"name" => "heineken", "objectID" => 3}}
+        ]
+      })
+    end
   end
 
-  test "reindex/1 with schemas" do
-    assert PeopleWithSchemas.reindex()
+  describe "reindex with association" do
+    test "reindex" do
+      assert {:ok, _} = PeopleWithAssociation.reindex()
+    end
 
-    assert_request("POST", %{
-      "requests" => [
-        %{"action" => "updateObject", "body" => %{"name" => "chimay", "objectID" => 1}}
-      ]
-    })
-
-    assert_request("POST", %{
-      "requests" => [
-        %{"action" => "updateObject", "body" => %{"name" => "jupiler", "objectID" => 2}}
-      ]
-    })
-  end
-
-  test "reindex/1 with schemas and multiple indexes" do
-    assert PeopleWithSchemasMultipleIndexes.reindex()
-
-    assert_request("POST", ~r/algoliax_with_schemas_en/, %{
-      "requests" => [
-        %{"action" => "updateObject", "body" => %{"name" => "chimay", "objectID" => 1}}
-      ]
-    })
-
-    assert_request("POST", ~r/algoliax_with_schemas_en/, %{
-      "requests" => [
-        %{"action" => "updateObject", "body" => %{"name" => "jupiler", "objectID" => 2}}
-      ]
-    })
-
-    assert_request("POST", ~r/algoliax_with_schemas_fr/, %{
-      "requests" => [
-        %{"action" => "updateObject", "body" => %{"name" => "chimay", "objectID" => 1}}
-      ]
-    })
-
-    assert_request("POST", ~r/algoliax_with_schemas_fr/, %{
-      "requests" => [
-        %{"action" => "updateObject", "body" => %{"name" => "jupiler", "objectID" => 2}}
-      ]
-    })
-  end
-
-  test "reindex/1 with schemas and query" do
-    query =
-      from(b in Beer,
-        where: b.name == "chimay"
-      )
-
-    assert {:ok, _} = PeopleWithSchemas.reindex(query)
-
-    assert_request("POST", %{
-      "requests" => [
-        %{"action" => "updateObject", "body" => %{"name" => "chimay", "objectID" => 1}}
-      ]
-    })
-  end
-
-  test "reindex/1 with schemas, query and multiple indexes" do
-    query =
-      from(b in Beer,
-        where: b.name == "chimay"
-      )
-
-    assert {:ok,
-            [
-              %Algoliax.Responses{
-                index_name: :algoliax_with_schemas_en,
-                responses: [
-                  {:ok, %Algoliax.Response{}}
-                ]
-              },
-              %Algoliax.Responses{
-                index_name: :algoliax_with_schemas_fr,
-                responses: [
-                  {:ok, %Algoliax.Response{}}
-                ]
-              }
-            ]} = PeopleWithSchemasMultipleIndexes.reindex(query)
-
-    assert_request("POST", ~r/algoliax_with_schemas_en/, %{
-      "requests" => [
-        %{"action" => "updateObject", "body" => %{"name" => "chimay", "objectID" => 1}}
-      ]
-    })
-
-    assert_request("POST", ~r/algoliax_with_schemas_fr/, %{
-      "requests" => [
-        %{"action" => "updateObject", "body" => %{"name" => "chimay", "objectID" => 1}}
-      ]
-    })
-  end
-
-  test "reindex/1 with schemas and query as keyword list" do
-    query = %{where: [name: "heineken"]}
-    assert {:ok, _} = PeopleWithSchemas.reindex(query)
-
-    assert_request("POST", %{
-      "requests" => [
-        %{"action" => "updateObject", "body" => %{"name" => "heineken", "objectID" => 3}}
-      ]
-    })
-  end
-
-  test "reindex/1 with schemas, query as keyword list and multiple indexes" do
-    query = %{where: [name: "heineken"]}
-
-    assert {:ok,
-            [
-              %Algoliax.Responses{
-                index_name: :algoliax_with_schemas_en,
-                responses: [
-                  {:ok, %Algoliax.Response{}}
-                ]
-              },
-              %Algoliax.Responses{
-                index_name: :algoliax_with_schemas_fr,
-                responses: [
-                  {:ok, %Algoliax.Response{}}
-                ]
-              }
-            ]} = PeopleWithSchemasMultipleIndexes.reindex(query)
-
-    assert_request("POST", ~r/algoliax_with_schemas_en/, %{
-      "requests" => [
-        %{"action" => "updateObject", "body" => %{"name" => "heineken", "objectID" => 3}}
-      ]
-    })
-
-    assert_request("POST", ~r/algoliax_with_schemas_fr/, %{
-      "requests" => [
-        %{"action" => "updateObject", "body" => %{"name" => "heineken", "objectID" => 3}}
-      ]
-    })
-  end
-
-  test "reindex/1 with association" do
-    assert {:ok, _} = PeopleWithAssociation.reindex()
-  end
-
-  test "reindex/1 with association and multiple indexes" do
-    assert {:ok, _} = PeopleWithAssociationMultipleIndexes.reindex()
+    test "with multiple indexes" do
+      assert {:ok, _} = PeopleWithAssociationMultipleIndexes.reindex()
+    end
   end
 
   describe "indexer w/ custom object id" do
@@ -954,6 +968,155 @@ defmodule AlgoliaxTest.Schema do
             "body" => %{
               "objectID" => "people-" <> @ref3,
               "last_name" => "Vador"
+            }
+          }
+        ]
+      })
+    end
+  end
+
+  describe "reindex with default_filters" do
+    test "reindex with default filters" do
+      # Expect 2 blondes
+      assert {:ok, [{:ok, %Algoliax.Response{}}, {:ok, %Algoliax.Response{}}]} =
+               BeerWithFilters.reindex()
+
+      assert_request("POST", %{
+        "requests" => [
+          %{
+            "action" => "updateObject",
+            "body" => %{
+              "kind" => "blonde",
+              "name" => "heineken",
+              "objectID" => 3
+            }
+          }
+        ]
+      })
+
+      assert_request("POST", %{
+        "requests" => [
+          %{
+            "action" => "updateObject",
+            "body" => %{
+              "kind" => "blonde",
+              "name" => "jupiler",
+              "objectID" => 2
+            }
+          }
+        ]
+      })
+    end
+
+    test "reindex with default filters per schemas" do
+      # Expect 1 brune
+      assert {:ok, [{:ok, %Algoliax.Response{}}]} = BeerWithSchemaFilters.reindex()
+
+      assert_request("POST", %{
+        "requests" => [
+          %{
+            "action" => "updateObject",
+            "body" => %{
+              "kind" => "brune",
+              "name" => "chimay",
+              "objectID" => 1
+            }
+          }
+        ]
+      })
+    end
+
+    test "reindex_atomic with default filters" do
+      # Expect 2 blondes
+      assert {:ok, :completed} = BeerWithFilters.reindex_atomic()
+
+      assert_request("POST", %{
+        "requests" => [
+          %{
+            "action" => "updateObject",
+            "body" => %{
+              "kind" => "blonde",
+              "name" => "heineken",
+              "objectID" => 3
+            }
+          }
+        ]
+      })
+
+      assert_request("POST", %{
+        "requests" => [
+          %{
+            "action" => "updateObject",
+            "body" => %{
+              "kind" => "blonde",
+              "name" => "jupiler",
+              "objectID" => 2
+            }
+          }
+        ]
+      })
+
+      assert_request("POST", ~r/algoliax_beer_with_filters\.tmp/, %{
+        "destination" => "algoliax_beer_with_filters",
+        "operation" => "move"
+      })
+    end
+
+    test "reindex_atomic with default filters per schemas" do
+      # Expect 1 brune
+      assert {:ok, :completed} = BeerWithSchemaFilters.reindex_atomic()
+
+      assert_request("POST", %{
+        "requests" => [
+          %{
+            "action" => "updateObject",
+            "body" => %{
+              "kind" => "brune",
+              "name" => "chimay",
+              "objectID" => 1
+            }
+          }
+        ]
+      })
+
+      assert_request("POST", ~r/algoliax_beer_with_schema_filters\.tmp/, %{
+        "destination" => "algoliax_beer_with_schema_filters",
+        "operation" => "move"
+      })
+    end
+
+    test "reindex ignore default filters if query is provided" do
+      # Expect 1 brune beer (as opposed to the default "2 blonde beers")
+      query = from(b in Beer, where: b.kind == "brune")
+      assert {:ok, [{:ok, %Algoliax.Response{}}]} = BeerWithFilters.reindex(query)
+
+      assert_request("POST", %{
+        "requests" => [
+          %{
+            "action" => "updateObject",
+            "body" => %{
+              "kind" => "brune",
+              "name" => "chimay",
+              "objectID" => 1
+            }
+          }
+        ]
+      })
+    end
+
+    test "reindex ignore default filters if query (keyword list) is provided" do
+      # Expect 1 blonde beer (as opposed to the default "1 brune beer")
+      query = %{where: [id: 2]}
+      assert {:ok, [{:ok, %Algoliax.Response{}}]} = BeerWithSchemaFilters.reindex(query)
+
+      assert_request("POST", %{
+        "requests" => [
+          %{
+            "action" => "updateObject",
+            "body" => %{
+              "kind" => "blonde",
+              "name" => "jupiler",
+              "objectID" => 2
             }
           }
         ]

--- a/test/algoliax/utils_test.exs
+++ b/test/algoliax/utils_test.exs
@@ -53,6 +53,39 @@ defmodule Algoliax.UtilsTest do
       object_id: :reference
   end
 
+  defmodule NoDefaultFilters do
+    use Algoliax.Indexer,
+      index_name: :algoliax_people,
+      attributes_for_faceting: ["age"],
+      searchable_attributes: ["full_name"],
+      custom_ranking: ["desc(updated_at)"],
+      object_id: :reference
+  end
+
+  defmodule DefaultFiltersInSettings do
+    use Algoliax.Indexer,
+      index_name: :algoliax_people,
+      attributes_for_faceting: ["age"],
+      searchable_attributes: ["full_name"],
+      custom_ranking: ["desc(updated_at)"],
+      object_id: :reference,
+      default_filters: %{where: [age: 42]}
+  end
+
+  defmodule DefaultFiltersWithFunction do
+    use Algoliax.Indexer,
+      index_name: :algoliax_people,
+      attributes_for_faceting: ["age"],
+      searchable_attributes: ["full_name"],
+      custom_ranking: ["desc(updated_at)"],
+      object_id: :reference,
+      default_filters: :default_filters
+
+    def default_filters do
+      %{where: [age: 43]}
+    end
+  end
+
   describe "Raise exception if trying Ecto specific methods" do
     test "Algoliax.MissingRepoError" do
       assert_raise(Algoliax.MissingRepoError, fn ->
@@ -107,6 +140,24 @@ defmodule Algoliax.UtilsTest do
                index_name: [:algoliax_people_en, :algoliax_people_fr]
              ) ==
                [:algoliax_people_en, :algoliax_people_fr]
+    end
+  end
+
+  describe "default_filters/2" do
+    test "not provided" do
+      assert Algoliax.Utils.default_filters(NoDefaultFilters, []) == %{}
+    end
+
+    test "provided in settings" do
+      assert Algoliax.Utils.default_filters(DefaultFiltersInSettings,
+               default_filters: %{where: [age: 42]}
+             ) == %{where: [age: 42]}
+    end
+
+    test "provided as a function" do
+      assert Algoliax.Utils.default_filters(DefaultFiltersWithFunction,
+               default_filters: :default_filters
+             ) == %{where: [age: 43]}
     end
   end
 end

--- a/test/support/repo.ex
+++ b/test/support/repo.ex
@@ -2,27 +2,4 @@ defmodule Algoliax.Repo do
   use Ecto.Repo,
     otp_app: :algoliax,
     adapter: Ecto.Adapters.Postgres
-
-  def init(_type, config) do
-    config =
-      config
-      |> put_env(:hostname)
-      |> put_env(:port)
-      |> put_env(:username)
-      |> put_env(:password)
-
-    {:ok, config}
-  end
-
-  defp put_env(config, key) do
-    case load_env(key) do
-      nil -> config
-      val -> Keyword.put(config, key, val)
-    end
-  end
-
-  defp load_env(:username), do: System.get_env("DB_USERNAME")
-  defp load_env(:password), do: System.get_env("DB_PASSWORD")
-  defp load_env(:hostname), do: System.get_env("POSTGRES_HOST")
-  defp load_env(:port), do: System.get_env("POSTGRES_PORT")
 end

--- a/test/support/schemas/beer_with_filters.ex
+++ b/test/support/schemas/beer_with_filters.ex
@@ -1,0 +1,26 @@
+defmodule Algoliax.Schemas.BeerWithFilters do
+  @moduledoc false
+
+  alias Algoliax.Schemas.Beer
+
+  use Algoliax.Indexer,
+    index_name: :algoliax_beer_with_filters,
+    repo: Algoliax.Repo,
+    schemas: [Beer],
+    algolia: [
+      attributes_for_faceting: ["kind", "name"],
+      searchable_attributes: ["kind", "name"],
+      custom_ranking: ["desc(updated_at)"]
+    ],
+    default_filters: %{where: [kind: "blonde"]}
+
+  def build_object(beer) do
+    %{
+      kind: beer.kind,
+      name: beer.name,
+      updated_at: ~U[2019-01-01 00:00:00Z] |> DateTime.to_unix()
+    }
+  end
+
+  def to_be_indexed?(_beer), do: true
+end

--- a/test/support/schemas/beer_with_schema_filters.ex
+++ b/test/support/schemas/beer_with_schema_filters.ex
@@ -1,0 +1,30 @@
+defmodule Algoliax.Schemas.BeerWithSchemaFilters do
+  @moduledoc false
+
+  alias Algoliax.Schemas.Beer
+
+  use Algoliax.Indexer,
+    index_name: :algoliax_beer_with_schema_filters,
+    repo: Algoliax.Repo,
+    schemas: [Beer],
+    algolia: [
+      attributes_for_faceting: ["kind", "name"],
+      searchable_attributes: ["kind", "name"],
+      custom_ranking: ["desc(updated_at)"]
+    ],
+    default_filters: :get_filters
+
+  def get_filters do
+    %{Beer => %{where: [kind: "brune"]}}
+  end
+
+  def build_object(beer) do
+    %{
+      kind: beer.kind,
+      name: beer.name,
+      updated_at: ~U[2019-01-01 00:00:00Z] |> DateTime.to_unix()
+    }
+  end
+
+  def to_be_indexed?(_beer), do: true
+end


### PR DESCRIPTION
## Recap
Added new **optional** settings `default_filters` to be applied automatically when calling `reindex` without query or `reindex_atomic`. Defaults to `%{}` which was the previous behavior. A few things to note:
- This is non-breaking
- Existing implementation will not be affected as it defaults to `%{}`
- We use the existing implementation of _"handling query keyword-list in reindex"_, but simply provide defaults filters when none are provided

Also added some quality of life improvements for local dev:
- New `CONTRIBUTING.md` file
- Simplified the `config/test.exs` file
- Provide a `.env.example` file to help contributors to setup their environment

## Why?

⚠️ In our case, we have a table of 1.2M rows with only 60k eligible for indexation. Running `reindex_atomic` takes forever because even though most records will be discarded by our `to_be_indexed?`, the 1.2M records are still behind fetched by chunks of 500 and evaluated for indexation individually. Which can lead to a 4+ hours runtime to reindex everything.

✅ With this settings, we provide the ability to automatically apply filters when using `reindex()` (ie without query) or `reindex_atomic` to avoid going through unnecessary records.

👍 Regarding "un-indexing" records that have been indexed with `force_delete`:
- reindex_atomic takes care of that
- You can still run a custom `reindex(query, force_delete: true)` with the query of your choice

## Usage

```elixir
defmodule BlondeBeerIndexer do
  use Algoliax.Indexer,
    index_name: :blonde_beers,
    object_id: :name,
    schemas: [Beer],
    default_filters: %{where: [kind: "blonde"]} # <---
end

defmodule BeerIndexer do
  use Algoliax.Indexer,
    index_name: :various_beers,
    object_id: :name,
    schemas: [Beer1, Beer2, Beer3],
    default_filters: :get_filters # <--- can be a function
    
  def get_filters do
    %{
      Beer1 => %{where: [kind: "blonde"]},  # <--- custom filter for Beer1
      :where => [kind: "brune"] # <--- Will be used for Beer2 and Beer3
    }
  end
end
```
