### PR TITLE
feat: added "if" option to replica for conditional deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## v0.8.3 - TBD
+## v0.8.3 - 2024-10-18
 
-New `to_be_deployed?` option for replicas which decides if they should be deployed or not.
+New `if` option for replicas which decides if they should be deployed or not.
 
 - **If not provided**, the replica will be deployed (so no impact on existing configurations)
 - Must be `nil|true|false` or the name (atom) of a arity-0 func which returns a boolean

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## v0.8.3 - 2024-10-18
 
-New `if` option for replicas which decides if they should be deployed or not.
+New `if` option for replicas which decides if they should be updated or not.
 
-- **If not provided**, the replica will be deployed (so no impact on existing configurations)
+- **If not provided**, the replica will be updated (so no impact on existing configurations)
 - Must be `nil|true|false` or the name (atom) of a arity-0 func which returns a boolean
-- If provided, the replica will be deployed only if the value is `true` or the function returns `true`
+- If provided, the replica will be updated only if the value is `true` or the function returns `true`
 
 Useful for Algolia's A/B testing which requires replicas and only deploy them in production.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.8.3 - TBD
+
+New `to_be_deployed?` option for replicas which decides if they should be deployed or not.
+
+- **If not provided**, the replica will be deployed (so no impact on existing configurations)
+- Must be `nil|true|false` or the name (atom) of a arity-0 func which returns a boolean
+- If provided, the replica will be deployed only if the value is `true` or the function returns `true`
+
+Useful for deploying replicas only under certain conditions, like on specific environments.
+
 ## v0.8.2 - 2024-09-16
 
 - Upgrading all dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ New `to_be_deployed?` option for replicas which decides if they should be deploy
 - Must be `nil|true|false` or the name (atom) of a arity-0 func which returns a boolean
 - If provided, the replica will be deployed only if the value is `true` or the function returns `true`
 
-Useful for deploying replicas only under certain conditions, like on specific environments.
+Useful for Algolia's A/B testing which requires replicas and only deploy them in production.
 
 ## v0.8.2 - 2024-09-16
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,7 @@ Then run `mix test` to run the tests.
 ## CI/CD
 
 We use CircleCI to:
+
 - Run the code_analysis (format/credo)
 - Check for vulnerabilities
 - Run the tests

--- a/lib/algoliax/exceptions.ex
+++ b/lib/algoliax/exceptions.ex
@@ -31,6 +31,19 @@ defmodule Algoliax.MissingIndexNameError do
   end
 end
 
+defmodule Algoliax.InvalidReplicaConfigurationError do
+  @moduledoc "Raise when a replica has an invalid configuration"
+
+  defexception [:message]
+
+  @impl true
+  def exception(%{index_name: index_name, error: error}) do
+    %__MODULE__{
+      message: "Invalid configuration for replica #{index_name}: #{error}"
+    }
+  end
+end
+
 defmodule Algoliax.AlgoliaApiError do
   @moduledoc "Raise Algolia API error"
 

--- a/lib/algoliax/resources/index.ex
+++ b/lib/algoliax/resources/index.ex
@@ -35,7 +35,7 @@ defmodule Algoliax.Resources.Index do
   def replicas_settings(module, settings) do
     settings
     |> Keyword.get(:replicas, [])
-    |> Enum.filter(fn replica -> should_be_deployed?(module, replica) end)
+    |> Enum.filter(fn replica -> should_be_updated?(module, replica) end)
     |> Enum.map(fn replica ->
       case Keyword.get(replica, :inherit, true) do
         true ->
@@ -54,7 +54,7 @@ defmodule Algoliax.Resources.Index do
     end)
   end
 
-  defp should_be_deployed?(module, replica) do
+  defp should_be_updated?(module, replica) do
     index_name = Keyword.get(replica, :index_name, nil)
 
     error_message =

--- a/lib/algoliax/resources/index.ex
+++ b/lib/algoliax/resources/index.ex
@@ -58,23 +58,23 @@ defmodule Algoliax.Resources.Index do
     index_name = Keyword.get(replica, :index_name, nil)
 
     error_message =
-      "`to_be_deployed?` must be `nil|true|false` or be the name of a 0-arity func which returns a boolean."
+      "`if` must be `nil|true|false` or be the name of a 0-arity func which returns a boolean."
 
-    to_be_deployed? = Keyword.get(replica, :to_be_deployed?, nil)
+    value = Keyword.get(replica, :if, nil)
 
     cond do
       # No config, defaults to true
-      is_nil(to_be_deployed?) ->
+      is_nil(value) ->
         true
 
       # Boolean, use this value
-      to_be_deployed? == true || to_be_deployed? == false ->
-        to_be_deployed?
+      value == true || value == false ->
+        value
 
       # Name of a 0-arity func
-      is_atom(to_be_deployed?) ->
-        if module.__info__(:functions) |> Keyword.get(to_be_deployed?) == 0 do
-          apply(module, to_be_deployed?, []) == true
+      is_atom(value) ->
+        if module.__info__(:functions) |> Keyword.get(value) == 0 do
+          apply(module, value, []) == true
         else
           raise Algoliax.InvalidReplicaConfigurationError, %{
             index_name: index_name,

--- a/lib/algoliax/resources/index.ex
+++ b/lib/algoliax/resources/index.ex
@@ -24,33 +24,69 @@ defmodule Algoliax.Resources.Index do
   end
 
   def replicas_names(module, settings, replica_index) do
-    settings
-    |> replicas_settings()
+    module
+    |> replicas_settings(settings)
     |> Enum.map(fn replica_settings ->
       index_name(module, replica_settings)
       |> Enum.at(replica_index)
     end)
   end
 
-  def replicas_settings(settings) do
-    replicas = Keyword.get(settings, :replicas, [])
-
-    Enum.map(replicas, fn replica ->
+  def replicas_settings(module, settings) do
+    settings
+    |> Keyword.get(:replicas, [])
+    |> Enum.filter(fn replica -> maybe_filter_replica(module, replica) end)
+    |> Enum.map(fn replica ->
       case Keyword.get(replica, :inherit, true) do
         true ->
           replica_algolia_settings = algolia_settings(replica)
-          primary_algolia_setttings = algolia_settings(settings)
+          primary_algolia_settings = algolia_settings(settings)
 
           Keyword.put(
             replica,
             :algolia,
-            Keyword.merge(primary_algolia_setttings, replica_algolia_settings)
+            Keyword.merge(primary_algolia_settings, replica_algolia_settings)
           )
 
         false ->
           replica
       end
     end)
+  end
+
+  defp maybe_filter_replica(module, replica) do
+    index_name = Keyword.get(replica, :index_name, nil)
+
+    error_message =
+      "`to_be_deployed?` must be `nil|true|false` or be the name of a 0-arity func which returns a boolean."
+
+    case Keyword.get(replica, :to_be_deployed?, nil) do
+      nil ->
+        true
+
+      atom when is_atom(atom) ->
+        is_valid_func = module.__info__(:functions) |> Keyword.get(atom) == 0
+
+        cond do
+          is_valid_func ->
+            apply(module, atom, []) == true
+
+          atom == true or atom == false ->
+            atom
+
+          true ->
+            raise Algoliax.InvalidReplicaConfigurationError, %{
+              index_name: index_name,
+              error: error_message
+            }
+        end
+
+      _ ->
+        raise Algoliax.InvalidReplicaConfigurationError, %{
+          index_name: index_name,
+          error: error_message
+        }
+    end
   end
 
   def get_settings(module, settings) do
@@ -80,8 +116,8 @@ defmodule Algoliax.Resources.Index do
   end
 
   def configure_replicas(module, settings) do
-    settings
-    |> replicas_settings()
+    module
+    |> replicas_settings(settings)
     |> Enum.map(fn replica_settings ->
       configure_index(module, replica_settings)
     end)

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Algoliax.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/WTTJ/algoliax"
-  @version "0.8.2"
+  @version "0.8.3"
 
   def project do
     [

--- a/test/algoliax/replica_test.exs
+++ b/test/algoliax/replica_test.exs
@@ -3,6 +3,7 @@ defmodule AlgoliaxTest.ReplicaTest do
 
   alias Algoliax.Schemas.PeopleWithReplicas
   alias Algoliax.Schemas.PeopleWithReplicasMultipleIndexes
+  alias Algoliax.Schemas.PeopleWithInvalidReplicas
 
   setup do
     Algoliax.SettingsStore.set_settings(:algoliax_people_replicas, %{})
@@ -76,7 +77,11 @@ defmodule AlgoliaxTest.ReplicaTest do
         body: %{
           "searchableAttributes" => ["full_name"],
           "attributesForFaceting" => ["age"],
-          "replicas" => ["algoliax_people_replicas_asc_en", "algoliax_people_replicas_desc_en"]
+          "replicas" => [
+            "algoliax_people_replicas_asc_en",
+            "algoliax_people_replicas_desc_en",
+            "algoliax_people_replicas_not_skipped_en"
+          ]
         }
       })
 
@@ -85,7 +90,11 @@ defmodule AlgoliaxTest.ReplicaTest do
         body: %{
           "searchableAttributes" => ["full_name"],
           "attributesForFaceting" => ["age"],
-          "replicas" => ["algoliax_people_replicas_asc_fr", "algoliax_people_replicas_desc_fr"]
+          "replicas" => [
+            "algoliax_people_replicas_asc_fr",
+            "algoliax_people_replicas_desc_fr",
+            "algoliax_people_replicas_not_skipped_fr"
+          ]
         }
       })
 
@@ -122,6 +131,24 @@ defmodule AlgoliaxTest.ReplicaTest do
           "searchableAttributes" => nil,
           "attributesForFaceting" => nil,
           "ranking" => ["desc(age)"]
+        }
+      })
+
+      assert_request("PUT", %{
+        path: ~r/algoliax_people_replicas_not_skipped_en/,
+        body: %{
+          "searchableAttributes" => ["age"],
+          "attributesForFaceting" => ["age"],
+          "ranking" => ["asc(age)"]
+        }
+      })
+
+      assert_request("PUT", %{
+        path: ~r/algoliax_people_replicas_not_skipped_fr/,
+        body: %{
+          "searchableAttributes" => ["age"],
+          "attributesForFaceting" => ["age"],
+          "ranking" => ["asc(age)"]
         }
       })
     end
@@ -523,6 +550,16 @@ defmodule AlgoliaxTest.ReplicaTest do
         path: ~r/algoliax_people_replicas_fr/,
         body: %{"facetQuery" => "2"}
       })
+    end
+
+    test "should raise error on invalid replica config" do
+      assert_raise(
+        Algoliax.InvalidReplicaConfigurationError,
+        "Invalid configuration for replica algoliax_people_replicas_asc: `to_be_deployed?` must be `nil|true|false` or be the name of a 0-arity func which returns a boolean.",
+        fn ->
+          PeopleWithInvalidReplicas.configure_index()
+        end
+      )
     end
   end
 end

--- a/test/algoliax/replica_test.exs
+++ b/test/algoliax/replica_test.exs
@@ -555,7 +555,7 @@ defmodule AlgoliaxTest.ReplicaTest do
     test "should raise error on invalid replica config" do
       assert_raise(
         Algoliax.InvalidReplicaConfigurationError,
-        "Invalid configuration for replica algoliax_people_replicas_asc: `to_be_deployed?` must be `nil|true|false` or be the name of a 0-arity func which returns a boolean.",
+        "Invalid configuration for replica algoliax_people_replicas_asc: `if` must be `nil|true|false` or be the name of a 0-arity func which returns a boolean.",
         fn ->
           PeopleWithInvalidReplicas.configure_index()
         end

--- a/test/support/schemas/people_with_invalid_replicas.ex
+++ b/test/support/schemas/people_with_invalid_replicas.ex
@@ -17,7 +17,7 @@ defmodule Algoliax.Schemas.PeopleWithInvalidReplicas do
           searchable_attributes: ["age"],
           ranking: ["asc(age)"]
         ],
-        to_be_deployed?: :ok
+        if: :ok
       ]
     ]
 

--- a/test/support/schemas/people_with_invalid_replicas.ex
+++ b/test/support/schemas/people_with_invalid_replicas.ex
@@ -1,0 +1,36 @@
+defmodule Algoliax.Schemas.PeopleWithInvalidReplicas do
+  @moduledoc false
+
+  use Algoliax.Indexer,
+    index_name: :algoliax_people_replicas,
+    object_id: :reference,
+    algolia: [
+      attributes_for_faceting: ["age"],
+      searchable_attributes: ["full_name"],
+      custom_ranking: ["desc(update_at)"]
+    ],
+    replicas: [
+      [
+        index_name: :algoliax_people_replicas_asc,
+        inherit: true,
+        algolia: [
+          searchable_attributes: ["age"],
+          ranking: ["asc(age)"]
+        ],
+        to_be_deployed?: :ok
+      ]
+    ]
+
+  defstruct reference: nil, last_name: nil, first_name: nil, age: nil
+
+  def build_object(people) do
+    %{
+      first_name: people.first_name,
+      last_name: people.last_name,
+      age: people.age,
+      updated_at: ~U[2019-01-01 00:00:00Z] |> DateTime.to_unix(),
+      full_name: Map.get(people, :first_name, "") <> " " <> Map.get(people, :last_name, ""),
+      nickname: Map.get(people, :first_name, "") |> String.downcase()
+    }
+  end
+end

--- a/test/support/schemas/people_with_replicas_multiple_indexes.ex
+++ b/test/support/schemas/people_with_replicas_multiple_indexes.ex
@@ -21,7 +21,41 @@ defmodule Algoliax.Schemas.PeopleWithReplicasMultipleIndexes do
       [
         index_name: [:algoliax_people_replicas_desc_en, :algoliax_people_replicas_desc_fr],
         inherit: false,
-        algolia: [ranking: ["desc(age)"]]
+        algolia: [ranking: ["desc(age)"]],
+        to_be_deployed?: true
+      ],
+      [
+        index_name: [:algoliax_people_replicas_skipped_en, :algoliax_people_replicas_skipped_fr],
+        inherit: true,
+        algolia: [
+          searchable_attributes: ["age"],
+          ranking: ["asc(age)"]
+        ],
+        to_be_deployed?: :do_not_deploy
+      ],
+      [
+        index_name: [
+          :algoliax_people_replicas_skipped_too_en,
+          :algoliax_people_replicas_skipped_too_fr
+        ],
+        inherit: true,
+        algolia: [
+          searchable_attributes: ["age"],
+          ranking: ["asc(age)"]
+        ],
+        to_be_deployed?: false
+      ],
+      [
+        index_name: [
+          :algoliax_people_replicas_not_skipped_en,
+          :algoliax_people_replicas_not_skipped_fr
+        ],
+        inherit: true,
+        algolia: [
+          searchable_attributes: ["age"],
+          ranking: ["asc(age)"]
+        ],
+        to_be_deployed?: :do_deploy
       ]
     ]
 
@@ -37,4 +71,7 @@ defmodule Algoliax.Schemas.PeopleWithReplicasMultipleIndexes do
       nickname: Map.get(people, :first_name, "") |> String.downcase()
     }
   end
+
+  def do_not_deploy, do: false
+  def do_deploy, do: true
 end

--- a/test/support/schemas/people_with_replicas_multiple_indexes.ex
+++ b/test/support/schemas/people_with_replicas_multiple_indexes.ex
@@ -22,7 +22,7 @@ defmodule Algoliax.Schemas.PeopleWithReplicasMultipleIndexes do
         index_name: [:algoliax_people_replicas_desc_en, :algoliax_people_replicas_desc_fr],
         inherit: false,
         algolia: [ranking: ["desc(age)"]],
-        to_be_deployed?: true
+        if: true
       ],
       [
         index_name: [:algoliax_people_replicas_skipped_en, :algoliax_people_replicas_skipped_fr],
@@ -31,7 +31,7 @@ defmodule Algoliax.Schemas.PeopleWithReplicasMultipleIndexes do
           searchable_attributes: ["age"],
           ranking: ["asc(age)"]
         ],
-        to_be_deployed?: :do_not_deploy
+        if: :do_not_deploy
       ],
       [
         index_name: [
@@ -43,7 +43,7 @@ defmodule Algoliax.Schemas.PeopleWithReplicasMultipleIndexes do
           searchable_attributes: ["age"],
           ranking: ["asc(age)"]
         ],
-        to_be_deployed?: false
+        if: false
       ],
       [
         index_name: [
@@ -55,7 +55,7 @@ defmodule Algoliax.Schemas.PeopleWithReplicasMultipleIndexes do
           searchable_attributes: ["age"],
           ranking: ["asc(age)"]
         ],
-        to_be_deployed?: :do_deploy
+        if: :do_deploy
       ]
     ]
 


### PR DESCRIPTION
New `if?` option for replicas which decides if they should be deployed or not.

- **If not provided**, the replica will be deployed (so no impact on existing configurations)
- Must be `nil|true|false` or the name (atom) of a arity-0 func which returns a boolean
- If provided, the replica will be deployed only if the value is `true` or the function returns `true`

Useful for deploying replicas only under certain conditions, like on specific environments.