### PR TITLE
feat: allow :algolia settings to be either static or dynamic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## TBD
+
+### New
+
+The `Algoliax.Indexer` now supports dynamic definition for the `:algolia` settings. It can supports 2 types of configurations:
+
+- (Existing) Keyword list
+- (New) Name of a 0-arity function that returns a keyword list
+
+```elixir
+defmodule People do
+  use Algoliax.Indexer,
+    index_name: :people,
+    object_id: :reference,
+    schemas: [People],
+    algolia: :runtime_algolia
+
+  def runtime_algolia do
+    [
+      attribute_for_faceting: ["age"],
+      custom_ranking: ["desc(updated_at)"]
+    ]
+  end
+end
+```
+
+Also added 2 new exceptions for the `:algolia` configuration: `InvalidAlgoliaSettingsFunctionError` and `InvalidAlgoliaSettingsConfigurationError`
+
+### Other changes
+
+Existing direct calls to `Algoliax.Settings.replica_settings/2` will still work but will not benefit from
+the dynamic `:algolia` configuration. Please use `Algoliax.Settings.replica_settings/3` instead.
+
 ## v0.9.0 - 2024-11-26
 
 `ALGOLIA_API_KEY` and `ALGOLIA_APPLICATION_ID` aren't read anymore from system env variables

--- a/lib/algoliax/exceptions.ex
+++ b/lib/algoliax/exceptions.ex
@@ -31,6 +31,33 @@ defmodule Algoliax.MissingIndexNameError do
   end
 end
 
+defmodule Algoliax.InvalidAlgoliaSettingsFunctionError do
+  @moduledoc "Raise when algolia settings are invalid"
+
+  defexception [:message]
+
+  @impl true
+  def exception(%{function_name: function_name}) do
+    %__MODULE__{
+      message: "Expected #{function_name} to be a 0-arity function that returns a list"
+    }
+  end
+end
+
+defmodule Algoliax.InvalidAlgoliaSettingsConfigurationError do
+  @moduledoc "Raise when algolia settings are invalid"
+
+  defexception [:message]
+
+  @impl true
+  def exception(_) do
+    %__MODULE__{
+      message:
+        "Settings must either be a keyword list or the name of a 0-arity function that returns a list"
+    }
+  end
+end
+
 defmodule Algoliax.InvalidReplicaConfigurationError do
   @moduledoc "Raise when a replica has an invalid configuration"
 

--- a/lib/algoliax/exceptions.ex
+++ b/lib/algoliax/exceptions.ex
@@ -32,7 +32,7 @@ defmodule Algoliax.MissingIndexNameError do
 end
 
 defmodule Algoliax.InvalidAlgoliaSettingsFunctionError do
-  @moduledoc "Raise when algolia settings are invalid"
+  @moduledoc "Raise when dynamic `:algolia` settings are invalid"
 
   defexception [:message]
 
@@ -45,7 +45,7 @@ defmodule Algoliax.InvalidAlgoliaSettingsFunctionError do
 end
 
 defmodule Algoliax.InvalidAlgoliaSettingsConfigurationError do
-  @moduledoc "Raise when algolia settings are invalid"
+  @moduledoc "Raise when the `:algolia` settings are unsupported"
 
   defexception [:message]
 

--- a/lib/algoliax/indexer.ex
+++ b/lib/algoliax/indexer.ex
@@ -9,7 +9,7 @@ defmodule Algoliax.Indexer do
   - `:cursor_field`: specify the column to be used to order and go through a given table. Default `:id`
   - `:schemas`: Specify which schemas used to populate index, Default: `[__CALLER__]`
   - `:default_filters`: Specify default filters to be used when reindex without providing a query. Must be a map or a function name (that returns a map). Default: `%{}`.
-  - `:algolia`: Any valid Algolia settings, using snake case or camel case. Ex: Algolia `attributeForFaceting` can be configured with `:attribute_for_faceting`
+  - `:algolia`: Any valid Algolia settings (using snake case or camel case, ie `attributeForFaceting` can be configured with `:attribute_for_faceting`) or the name of 0-arity function that returns those settings.
 
   On first call to Algolia, we check that the settings on Algolia are up to date.
 
@@ -137,21 +137,26 @@ defmodule Algoliax.Indexer do
         end
       end
 
-  ### Configure index name at runtime
+  ### Configure index name and algolia settings at runtime
 
-  To support code for multiple environments, you can also define the index name at runtime. To achieve this, create a function within your indexer module and reference it using its atom in the Indexer configuration.
+  To support code for multiple environments, you can also define things like index_name or algolia settings at runtime.
+  To achieve this, create a function within your indexer module and reference it using its atom in the Indexer configuration.
 
   ```elixir
   defmodule People do
     use Algoliax.Indexer,
       index_name: :runtime_index_name,
       #....
+      algolia: :runtime_algolia
 
     def runtime_index_name do
       System.get_env("INDEX_NAME")
     end
+
+    def runtime_algolia do
+      [attribute_for_faceting: ["age"]]
+    end
   end
-  ```
   """
 
   alias Algoliax.Resources.{Index, Object, Search}

--- a/lib/algoliax/resources/index.ex
+++ b/lib/algoliax/resources/index.ex
@@ -1,7 +1,7 @@
 defmodule Algoliax.Resources.Index do
   @moduledoc false
 
-  import Algoliax.Utils, only: [index_name: 2, algolia_settings: 1, render_response: 1]
+  import Algoliax.Utils, only: [index_name: 2, algolia_settings: 2, render_response: 1]
   import Algoliax.Client, only: [request: 1]
 
   alias Algoliax.{Settings, SettingsStore}
@@ -39,8 +39,8 @@ defmodule Algoliax.Resources.Index do
     |> Enum.map(fn replica ->
       case Keyword.get(replica, :inherit, true) do
         true ->
-          replica_algolia_settings = algolia_settings(replica)
-          primary_algolia_settings = algolia_settings(settings)
+          replica_algolia_settings = algolia_settings(module, replica)
+          primary_algolia_settings = algolia_settings(module, settings)
 
           Keyword.put(
             replica,
@@ -149,8 +149,8 @@ defmodule Algoliax.Resources.Index do
   end
 
   defp settings_to_algolia_settings(module, settings, replica_index) do
-    settings
-    |> algolia_settings()
+    module
+    |> algolia_settings(settings)
     |> Settings.map_algolia_settings()
     |> add_replicas_to_algolia_settings(module, settings, replica_index)
   end

--- a/lib/algoliax/settings.ex
+++ b/lib/algoliax/settings.ex
@@ -1,7 +1,7 @@
 defmodule Algoliax.Settings do
   @moduledoc false
 
-  import Algoliax.Utils, only: [camelize: 1, algolia_settings: 1]
+  import Algoliax.Utils, only: [camelize: 1, algolia_settings: 2]
 
   @algolia_settings [
     :searchable_attributes,
@@ -60,10 +60,13 @@ defmodule Algoliax.Settings do
     @algolia_settings
   end
 
-  def replica_settings(settings, replica_settings) do
+  def replica_settings(settings, replica_settings),
+    do: replica_settings(%{}, settings, replica_settings)
+
+  def replica_settings(module, settings, replica_settings) do
     replica_settings =
       case Keyword.get(replica_settings, :inherit, true) do
-        true -> replica_settings ++ algolia_settings(settings)
+        true -> replica_settings ++ algolia_settings(module, settings)
         false -> replica_settings
       end
 

--- a/test/algoliax/settings_test.exs
+++ b/test/algoliax/settings_test.exs
@@ -1,6 +1,15 @@
 defmodule Algoliax.SettingsTest do
   use ExUnit.Case, async: true
 
+  defmodule ModuleWithAlgoliaSettingsFunc do
+    def algolia_settings do
+      [
+        attributes_for_faceting: ["location"],
+        searchable_attributes: ["first_name"]
+      ]
+    end
+  end
+
   test "settings/0" do
     assert Algoliax.Settings.settings() == [
              :searchable_attributes,
@@ -131,6 +140,34 @@ defmodule Algoliax.SettingsTest do
 
       assert result["attributesForFaceting"] == ["age"]
       assert result["searchableAttributes"] == nil
+      assert result["ranking"] == ["asc(age)"]
+    end
+
+    test "with algolia settings func" do
+      replica_settings = [
+        name: :algoliax_people_by_age_asc,
+        attributes_for_faceting: ["age"],
+        ranking: ["asc(age)"],
+        inherit: true
+      ]
+
+      settings = [
+        index_name: :algoliax_people,
+        object_id: :reference,
+        repo: MyApp.Repo,
+        algolia: :algolia_settings,
+        replicas: [replica_settings]
+      ]
+
+      assert result =
+               Algoliax.Settings.replica_settings(
+                 ModuleWithAlgoliaSettingsFunc,
+                 settings,
+                 replica_settings
+               )
+
+      assert result["attributesForFaceting"] == ["age"]
+      assert result["searchableAttributes"] == ["first_name"]
       assert result["ranking"] == ["asc(age)"]
     end
   end

--- a/test/algoliax/utils_test.exs
+++ b/test/algoliax/utils_test.exs
@@ -102,9 +102,6 @@ defmodule Algoliax.UtilsTest do
     end
   end
 
-  defmodule FakeModule do
-  end
-
   defmodule AlgoliaSettingsFunction do
     def valid_func do
       [
@@ -181,11 +178,11 @@ defmodule Algoliax.UtilsTest do
 
   describe "algolia_settings/2" do
     test "with a nothing" do
-      assert Algoliax.Utils.algolia_settings(FakeModule, []) == []
+      assert Algoliax.Utils.algolia_settings(%{}, []) == []
     end
 
     test "with a list" do
-      assert Algoliax.Utils.algolia_settings(FakeModule,
+      assert Algoliax.Utils.algolia_settings(%{},
                algolia: [
                  attributes_for_faceting: ["age"],
                  searchable_attributes: ["full_name"]

--- a/test/algoliax/utils_test.exs
+++ b/test/algoliax/utils_test.exs
@@ -4,18 +4,22 @@ defmodule Algoliax.UtilsTest do
   defmodule NoRepo do
     use Algoliax.Indexer,
       index_name: :algoliax_people,
-      attributes_for_faceting: ["age"],
-      searchable_attributes: ["full_name"],
-      custom_ranking: ["desc(updated_at)"],
+      algolia: [
+        attributes_for_faceting: ["age"],
+        searchable_attributes: ["full_name"],
+        custom_ranking: ["desc(updated_at)"]
+      ],
       object_id: :reference
   end
 
   defmodule IndexNameFromFunction do
     use Algoliax.Indexer,
       index_name: :algoliax_people,
-      attributes_for_faceting: ["age"],
-      searchable_attributes: ["full_name"],
-      custom_ranking: ["desc(updated_at)"],
+      algolia: [
+        attributes_for_faceting: ["age"],
+        searchable_attributes: ["full_name"],
+        custom_ranking: ["desc(updated_at)"]
+      ],
       object_id: :reference
 
     def algoliax_people do
@@ -26,18 +30,22 @@ defmodule Algoliax.UtilsTest do
   defmodule MultipleIndexNames do
     use Algoliax.Indexer,
       index_name: [:algoliax_people_en, :algoliax_people_fr],
-      attributes_for_faceting: ["age"],
-      searchable_attributes: ["full_name"],
-      custom_ranking: ["desc(updated_at)"],
+      algolia: [
+        attributes_for_faceting: ["age"],
+        searchable_attributes: ["full_name"],
+        custom_ranking: ["desc(updated_at)"]
+      ],
       object_id: :reference
   end
 
   defmodule MultipleIndexNameFromFunction do
     use Algoliax.Indexer,
       index_name: :algoliax_people,
-      attributes_for_faceting: ["age"],
-      searchable_attributes: ["full_name"],
-      custom_ranking: ["desc(updated_at)"],
+      algolia: [
+        attributes_for_faceting: ["age"],
+        searchable_attributes: ["full_name"],
+        custom_ranking: ["desc(updated_at)"]
+      ],
       object_id: :reference
 
     def algoliax_people do
@@ -47,27 +55,33 @@ defmodule Algoliax.UtilsTest do
 
   defmodule NoIndexName do
     use Algoliax.Indexer,
-      attributes_for_faceting: ["age"],
-      searchable_attributes: ["full_name"],
-      custom_ranking: ["desc(updated_at)"],
+      algolia: [
+        attributes_for_faceting: ["age"],
+        searchable_attributes: ["full_name"],
+        custom_ranking: ["desc(updated_at)"]
+      ],
       object_id: :reference
   end
 
   defmodule NoDefaultFilters do
     use Algoliax.Indexer,
       index_name: :algoliax_people,
-      attributes_for_faceting: ["age"],
-      searchable_attributes: ["full_name"],
-      custom_ranking: ["desc(updated_at)"],
+      algolia: [
+        attributes_for_faceting: ["age"],
+        searchable_attributes: ["full_name"],
+        custom_ranking: ["desc(updated_at)"]
+      ],
       object_id: :reference
   end
 
   defmodule DefaultFiltersInSettings do
     use Algoliax.Indexer,
       index_name: :algoliax_people,
-      attributes_for_faceting: ["age"],
-      searchable_attributes: ["full_name"],
-      custom_ranking: ["desc(updated_at)"],
+      algolia: [
+        attributes_for_faceting: ["age"],
+        searchable_attributes: ["full_name"],
+        custom_ranking: ["desc(updated_at)"]
+      ],
       object_id: :reference,
       default_filters: %{where: [age: 42]}
   end
@@ -75,14 +89,36 @@ defmodule Algoliax.UtilsTest do
   defmodule DefaultFiltersWithFunction do
     use Algoliax.Indexer,
       index_name: :algoliax_people,
-      attributes_for_faceting: ["age"],
-      searchable_attributes: ["full_name"],
-      custom_ranking: ["desc(updated_at)"],
+      algolia: [
+        attributes_for_faceting: ["age"],
+        searchable_attributes: ["full_name"],
+        custom_ranking: ["desc(updated_at)"]
+      ],
       object_id: :reference,
       default_filters: :default_filters
 
     def default_filters do
       %{where: [age: 43]}
+    end
+  end
+
+  defmodule FakeModule do
+  end
+
+  defmodule AlgoliaSettingsFunction do
+    def valid_func do
+      [
+        attributes_for_faceting: ["age2"],
+        searchable_attributes: ["full_name2"]
+      ]
+    end
+
+    def invalid_return_func do
+      :invalid
+    end
+
+    def invalid_arity_func(arg) do
+      arg
     end
   end
 
@@ -140,6 +176,55 @@ defmodule Algoliax.UtilsTest do
                index_name: [:algoliax_people_en, :algoliax_people_fr]
              ) ==
                [:algoliax_people_en, :algoliax_people_fr]
+    end
+  end
+
+  describe "algolia_settings/2" do
+    test "with a nothing" do
+      assert Algoliax.Utils.algolia_settings(FakeModule, []) == []
+    end
+
+    test "with a list" do
+      assert Algoliax.Utils.algolia_settings(FakeModule,
+               algolia: [
+                 attributes_for_faceting: ["age"],
+                 searchable_attributes: ["full_name"]
+               ]
+             ) == [
+               attributes_for_faceting: ["age"],
+               searchable_attributes: ["full_name"]
+             ]
+    end
+
+    test "with a function" do
+      assert Algoliax.Utils.algolia_settings(AlgoliaSettingsFunction, algolia: :valid_func) == [
+               attributes_for_faceting: ["age2"],
+               searchable_attributes: ["full_name2"]
+             ]
+    end
+
+    test "with a function with invalid return" do
+      assert_raise(Algoliax.InvalidAlgoliaSettingsFunctionError, fn ->
+        Algoliax.Utils.algolia_settings(AlgoliaSettingsFunction, algolia: :invalid_return_func)
+      end)
+    end
+
+    test "with an unknown function" do
+      assert_raise(Algoliax.InvalidAlgoliaSettingsFunctionError, fn ->
+        Algoliax.Utils.algolia_settings(AlgoliaSettingsFunction, algolia: :unknown_func)
+      end)
+    end
+
+    test "with an non-0-arity function" do
+      assert_raise(Algoliax.InvalidAlgoliaSettingsFunctionError, fn ->
+        Algoliax.Utils.algolia_settings(AlgoliaSettingsFunction, algolia: :invalid_arity_func)
+      end)
+    end
+
+    test "with a map" do
+      assert_raise(Algoliax.InvalidAlgoliaSettingsConfigurationError, fn ->
+        Algoliax.Utils.algolia_settings(AlgoliaSettingsFunction, algolia: 42)
+      end)
     end
   end
 

--- a/test/support/schemas/people_with_replicas.ex
+++ b/test/support/schemas/people_with_replicas.ex
@@ -4,19 +4,12 @@ defmodule Algoliax.Schemas.PeopleWithReplicas do
   use Algoliax.Indexer,
     index_name: :algoliax_people_replicas,
     object_id: :reference,
-    algolia: [
-      attributes_for_faceting: ["age"],
-      searchable_attributes: ["full_name"],
-      custom_ranking: ["desc(update_at)"]
-    ],
+    algolia: :runtime_algolia_settings,
     replicas: [
       [
         index_name: :algoliax_people_replicas_asc,
         inherit: true,
-        algolia: [
-          searchable_attributes: ["age"],
-          ranking: ["asc(age)"]
-        ]
+        algolia: :runtime_replica_algolia_settings
       ],
       [
         index_name: :algoliax_people_replicas_desc,
@@ -36,5 +29,20 @@ defmodule Algoliax.Schemas.PeopleWithReplicas do
       full_name: Map.get(people, :first_name, "") <> " " <> Map.get(people, :last_name, ""),
       nickname: Map.get(people, :first_name, "") |> String.downcase()
     }
+  end
+
+  def runtime_algolia_settings do
+    [
+      attributes_for_faceting: ["age"],
+      searchable_attributes: ["full_name"],
+      custom_ranking: ["desc(update_at)"]
+    ]
+  end
+
+  def runtime_replica_algolia_settings do
+    [
+      searchable_attributes: ["age"],
+      ranking: ["asc(age)"]
+    ]
   end
 end


### PR DESCRIPTION
### New

The `Algoliax.Indexer` now supports dynamic definition for the `:algolia` settings. It can supports 2 types of configurations:

- (Existing) Keyword list
- (New) Name of a 0-arity function that returns a keyword list

```elixir
defmodule People do
  use Algoliax.Indexer,
    index_name: :people,
    object_id: :reference,
    schemas: [People],
    algolia: :runtime_algolia

  def runtime_algolia do
    [
      attribute_for_faceting: ["age"],
      custom_ranking: ["desc(updated_at)"]
    ]
  end
end
```

Also added 2 new exceptions for the `:algolia` configuration: `InvalidAlgoliaSettingsFunctionError` and `InvalidAlgoliaSettingsConfigurationError`

### Other changes

Existing direct calls to `Algoliax.Settings.replica_settings/2` will still work but will not benefit from
the dynamic `:algolia` configuration. Please use `Algoliax.Settings.replica_settings/3` instead.